### PR TITLE
Design completion: graph interactions, dedup pass, analysis cards

### DIFF
--- a/Atria/Atria/AtriaActivityMonitor.swift
+++ b/Atria/Atria/AtriaActivityMonitor.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Charts
 
 /// Activity Monitor — every logged activity (sleep, naps, workouts) in one
 /// place, grouped by day newest-first, each row tappable to review or adjust.
@@ -16,6 +17,10 @@ struct AtriaActivityMonitorTab: View {
 
     @State private var workoutDetail: UserConfirmedWorkout?
     @State private var showAddWorkout = false
+    /// Day shown in the header timeline (user feedback 2026-07-07: "the top
+    /// of activity should have an entire graph with activities listed and
+    /// days can be changed").
+    @State private var timelineDay: Date = Calendar.current.startOfDay(for: Date())
 
     private enum Entry: Identifiable {
         case sleep(SleepHistorySnapshot.Night)
@@ -64,6 +69,8 @@ struct AtriaActivityMonitorTab: View {
 
             addActivityMenu
 
+            dayTimelineCard
+
             let sections = daySections
             if sections.isEmpty {
                 emptyState
@@ -83,6 +90,122 @@ struct AtriaActivityMonitorTab: View {
                 .presentationDetents([.medium, .large])
                 .presentationDragIndicator(.visible)
         }
+    }
+
+    /// A span of one activity clipped to the selected day, for the header
+    /// timeline lanes.
+    private struct TimelineSpan: Identifiable {
+        let id: String
+        let lane: String
+        let start: Date
+        let end: Date
+        let tint: Color
+        let label: String
+    }
+
+    private var timelineSpans: [TimelineSpan] {
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: timelineDay)
+        guard let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) else { return [] }
+
+        var spans: [TimelineSpan] = []
+        for night in store.sleepHistorySnapshot.nights {
+            guard let start = night.start, let end = night.end,
+                  end > dayStart, start < dayEnd else { continue }
+            spans.append(TimelineSpan(id: "sleep-\(night.id)",
+                                      lane: night.isNapEvidence ? "Nap" : "Sleep",
+                                      start: max(start, dayStart),
+                                      end: min(end, dayEnd),
+                                      tint: Metrics.electricSleep,
+                                      label: night.isNapEvidence ? "Nap" : "Sleep"))
+        }
+        for workout in store.confirmedWorkouts {
+            guard workout.end > dayStart, workout.start < dayEnd else { continue }
+            spans.append(TimelineSpan(id: "workout-\(workout.id)",
+                                      lane: "Workout",
+                                      start: max(workout.start, dayStart),
+                                      end: min(workout.end, dayEnd),
+                                      tint: Metrics.electricStrain,
+                                      label: workout.activitySubtype ?? workout.activityType ?? "Workout"))
+        }
+        return spans
+    }
+
+    private var canGoToNextDay: Bool {
+        Calendar.current.startOfDay(for: timelineDay) < Calendar.current.startOfDay(for: Date())
+    }
+
+    private var dayTimelineCard: some View {
+        let calendar = Calendar.current
+        let dayStart = calendar.startOfDay(for: timelineDay)
+        let dayEnd = calendar.date(byAdding: .day, value: 1, to: dayStart) ?? dayStart
+        let spans = timelineSpans
+
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Button {
+                    if let previous = calendar.date(byAdding: .day, value: -1, to: timelineDay) {
+                        timelineDay = previous
+                    }
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .font(.subheadline.weight(.bold))
+                        .frame(width: 40, height: 40)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Previous day")
+
+                Spacer(minLength: 0)
+                Text(calendar.isDateInToday(timelineDay)
+                     ? "Today"
+                     : timelineDay.formatted(.dateTime.weekday(.wide).month(.abbreviated).day()))
+                    .font(.subheadline.weight(.bold))
+                Spacer(minLength: 0)
+
+                Button {
+                    if let next = calendar.date(byAdding: .day, value: 1, to: timelineDay) {
+                        timelineDay = next
+                    }
+                } label: {
+                    Image(systemName: "chevron.right")
+                        .font(.subheadline.weight(.bold))
+                        .frame(width: 40, height: 40)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!canGoToNextDay)
+                .opacity(canGoToNextDay ? 1 : 0.3)
+                .accessibilityLabel("Next day")
+            }
+
+            if spans.isEmpty {
+                Text("Nothing recorded this day.")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, minHeight: 84)
+            } else {
+                Chart(spans) { span in
+                    BarMark(xStart: .value("Start", span.start),
+                            xEnd: .value("End", span.end),
+                            y: .value("Lane", span.lane))
+                        .foregroundStyle(span.tint.opacity(0.85))
+                        .cornerRadius(4)
+                }
+                .chartXScale(domain: dayStart...dayEnd)
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .hour, count: 6)) { _ in
+                        AxisGridLine()
+                        AxisValueLabel(format: .dateTime.hour())
+                    }
+                }
+                .frame(height: max(64, CGFloat(Set(spans.map(\.lane)).count) * 34 + 30))
+                .clipped()
+            }
+        }
+        .padding(14)
+        .atriaCard(emphasis: .soft)
+        .animation(.snappy(duration: 0.2), value: timelineDay)
     }
 
     private var addActivityMenu: some View {

--- a/Atria/Atria/AtriaActivityMonitor.swift
+++ b/Atria/Atria/AtriaActivityMonitor.swift
@@ -416,6 +416,48 @@ private struct AtriaActivityWorkoutDetailSheet: View {
         _endTime = State(initialValue: workout.end)
     }
 
+    /// The workout window's real recorded HR samples from the saved
+    /// sessions that overlap it. Empty when no session covered the window
+    /// (e.g. a manually added workout) — the card then doesn't render.
+    private var heartRateTracePoints: [AtriaHomeModel.HeartRateChartPoint] {
+        store.sessions
+            .filter { $0.end > workout.start && $0.start < workout.end }
+            .flatMap { session in
+                session.points.compactMap { point -> AtriaHomeModel.HeartRateChartPoint? in
+                    let t = session.start.addingTimeInterval(point.t)
+                    guard t >= workout.start, t <= workout.end, point.bpm > 0 else { return nil }
+                    return AtriaHomeModel.HeartRateChartPoint(t: t, bpm: point.bpm)
+                }
+            }
+            .sorted { $0.t < $1.t }
+    }
+
+    /// Per-workout HR trace (design backlog item 6). Reuses the shared axis
+    /// chart, which auto-smooths dense windows into an average + min-max
+    /// band per the 2026-07-07 feedback.
+    @ViewBuilder
+    private var heartRateTraceCard: some View {
+        let points = heartRateTracePoints
+        if points.count >= 30 {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Heart-rate trace")
+                    .font(.subheadline.weight(.semibold))
+                AtriaHeartRateAxisChart(points: points,
+                                        yDomain: AtriaHeartRateChartSeries.yDomain(for: points),
+                                        selectedTime: .constant(nil))
+                    .frame(height: 150)
+                    .clipped()
+                Text("Recorded strap samples during this workout.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(12)
+            .atriaInsetCard(tint: .red)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Heart-rate trace, \(points.count) samples during this workout.")
+        }
+    }
+
     private var timesChanged: Bool {
         abs(startTime.timeIntervalSince(workout.start)) >= 60
             || abs(endTime.timeIntervalSince(workout.end)) >= 60
@@ -435,6 +477,8 @@ private struct AtriaActivityWorkoutDetailSheet: View {
                 VStack(alignment: .leading, spacing: 16) {
                     AtriaPanelSectionHeader(title: "Workout",
                                             subtitle: Self.rangeText(workout))
+
+                    heartRateTraceCard
 
                     VStack(alignment: .leading, spacing: 8) {
                         Text("NAME")

--- a/Atria/Atria/AtriaActivityMonitor.swift
+++ b/Atria/Atria/AtriaActivityMonitor.swift
@@ -658,7 +658,7 @@ private struct AtriaActivityWorkoutDetailSheet: View {
 /// didn't surface (e.g. a walk or dance you wore the strap for). Metrics are
 /// derived from the strap samples in that window — if there were none, it can't
 /// be saved, because Atria never invents heart rate or strain.
-private struct AtriaAddWorkoutSheet: View {
+struct AtriaAddWorkoutSheet: View {
     @ObservedObject var store: SessionStore
     @Environment(\.dismiss) private var dismiss
 
@@ -667,11 +667,14 @@ private struct AtriaAddWorkoutSheet: View {
     @State private var endTime: Date
     @State private var failed = false
 
-    init(store: SessionStore) {
+    /// Seedable window (2026-07-07): the detections inbox opens this sheet
+    /// pre-filled with a detected-but-unsaved window. Internal (not private)
+    /// for that same reason.
+    init(store: SessionStore, initialStart: Date? = nil, initialEnd: Date? = nil) {
         self.store = store
         let now = Date()
-        _endTime = State(initialValue: now)
-        _startTime = State(initialValue: now.addingTimeInterval(-45 * 60))
+        _endTime = State(initialValue: initialEnd ?? now)
+        _startTime = State(initialValue: initialStart ?? (initialEnd ?? now).addingTimeInterval(-45 * 60))
     }
 
     var body: some View {

--- a/Atria/Atria/AtriaCycleTracking.swift
+++ b/Atria/Atria/AtriaCycleTracking.swift
@@ -282,6 +282,51 @@ final class AtriaCycleTrackingStore: ObservableObject {
 
         return AtriaCycleEstimate(phase: phase, cycleDay: wrappedDay, confidence: confidence)
     }
+
+    /// Phase estimate for a PAST day, or nil when the day can't honestly be
+    /// classified: before the first logged period, or beyond one median
+    /// cycle length after its anchoring period start (unlike
+    /// `currentEstimate`, history never wraps — an unlogged stretch stays
+    /// unclassified rather than guessed).
+    func phaseEstimate(on day: Date, calendar: Calendar = .current) -> AtriaCyclePhase? {
+        loadIfNeeded()
+        let target = calendar.startOfDay(for: day)
+        guard let anchor = entries.last(where: { calendar.startOfDay(for: $0.start) <= target }) else { return nil }
+        let cycleLength = medianCycleLengthDays ?? Self.calendarDefaultCycleLength
+        let periodLength = min(medianPeriodLengthDays, cycleLength - 1)
+        let dayIndex = (calendar.dateComponents([.day], from: calendar.startOfDay(for: anchor.start), to: target).day ?? 0) + 1
+        guard dayIndex >= 1, dayIndex <= cycleLength else { return nil }
+        let ovulationDay = max(periodLength + 1, cycleLength - Self.lutealPhaseLength)
+        if dayIndex <= periodLength { return .menstrual }
+        if dayIndex < ovulationDay - 1 { return .follicular }
+        if dayIndex <= ovulationDay + 1 { return .ovulatory }
+        return .luteal
+    }
+
+    /// Average recovery per phase over the trailing 90 days. Only rendered
+    /// once the estimate is personalized (>=2 completed cycles) and only for
+    /// phases with at least `minimumDaysPerPhase` classified recovery days.
+    static let minimumDaysPerPhase = 3
+
+    func recoveryPatternsByPhase(days: [(day: Date, recovery: Int?)],
+                                 now: Date = Date(),
+                                 calendar: Calendar = .current) -> [(phase: AtriaCyclePhase, averageRecovery: Int, dayCount: Int)] {
+        loadIfNeeded()
+        guard completedCycleCount >= 2 else { return [] }
+        let windowStart = calendar.date(byAdding: .day, value: -90, to: calendar.startOfDay(for: now))
+            ?? calendar.startOfDay(for: now)
+        var buckets: [AtriaCyclePhase: [Int]] = [:]
+        for entry in days {
+            guard let recovery = entry.recovery,
+                  entry.day >= windowStart,
+                  let phase = phaseEstimate(on: entry.day, calendar: calendar) else { continue }
+            buckets[phase, default: []].append(recovery)
+        }
+        return AtriaCyclePhase.allCases.compactMap { phase in
+            guard let values = buckets[phase], values.count >= Self.minimumDaysPerPhase else { return nil }
+            return (phase: phase, averageRecovery: values.reduce(0, +) / values.count, dayCount: values.count)
+        }
+    }
 }
 
 extension JSONEncoder {

--- a/Atria/Atria/AtriaDetectionLog.swift
+++ b/Atria/Atria/AtriaDetectionLog.swift
@@ -20,13 +20,21 @@ struct DetectionEvent: Codable, Equatable, Identifiable {
     /// fabricated, only ever built from real fields already computed at the
     /// call site.
     let detail: String
+    /// The detected activity's real window (2026-07-07, design backlog:
+    /// actionable workout rows). Optional and additive — events logged by
+    /// older builds decode without them and stay read-only.
+    var windowStart: Date? = nil
+    var windowEnd: Date? = nil
 
-    init(kind: String, reason: String? = nil, date: Date = Date(), detail: String) {
+    init(kind: String, reason: String? = nil, date: Date = Date(), detail: String,
+         windowStart: Date? = nil, windowEnd: Date? = nil) {
         self.id = UUID()
         self.kind = kind
         self.reason = reason
         self.date = date
         self.detail = detail
+        self.windowStart = windowStart
+        self.windowEnd = windowEnd
     }
 }
 

--- a/Atria/Atria/AtriaExpandedChart.swift
+++ b/Atria/Atria/AtriaExpandedChart.swift
@@ -1,0 +1,233 @@
+import SwiftUI
+import Charts
+
+/// An event overlaid on an expanded chart — a workout, confirmed sleep, or
+/// journal entry that happened on that day. Only ever built from real saved
+/// records; an empty list simply renders no marker lane.
+struct AtriaChartEvent: Identifiable, Equatable {
+    let id: String
+    let day: Date
+    let label: String
+    let systemImage: String
+    let tint: Color
+}
+
+/// Shared expanded-chart experience (user feedback 2026-07-07: "all of the
+/// graphs should have basic functions and open in landscape mode when
+/// expanded"). Presented full-screen; the canvas renders rotated 90° so the
+/// chart reads landscape when the phone is turned on its side — no
+/// orientation-lock fight. Interactions: pinch/scroll zoom via the native
+/// visible x-domain, drag-brush range selection with an honest window
+/// summary, and a real-event marker lane.
+struct AtriaExpandedChartView: View {
+    let title: String
+    let unit: String
+    let tint: Color
+    let points: [AtriaDetailChartPoint]
+    var priorPoints: [AtriaDetailChartPoint] = []
+    var baselineBand: AtriaDetailBaselineBand? = nil
+    var events: [AtriaChartEvent] = []
+    let onDismiss: () -> Void
+
+    @State private var visibleDays: Int = 0
+    @State private var brushStart: Date?
+    @State private var brushEnd: Date?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var spanDays: Int {
+        guard let first = points.first?.day, let last = points.last?.day else { return 1 }
+        return max(1, Calendar.current.dateComponents([.day], from: first, to: last).day ?? 1)
+    }
+
+    var body: some View {
+        GeometryReader { proxy in
+            let landscapeWidth = max(proxy.size.width, proxy.size.height) - 32
+            let landscapeHeight = min(proxy.size.width, proxy.size.height) - 96
+            ZStack {
+                Color.black.ignoresSafeArea()
+
+                VStack(spacing: 10) {
+                    header
+                    chartBody
+                        .frame(width: landscapeWidth, height: landscapeHeight - 60)
+                    footer
+                }
+                .frame(width: landscapeWidth, height: landscapeHeight)
+                // Landscape canvas on a portrait screen: rotate the whole
+                // stage 90°; turning the phone makes it read upright. The
+                // explicit position re-centers the oversized pre-rotation
+                // frame inside the screen.
+                .rotationEffect(.degrees(proxy.size.height > proxy.size.width ? 90 : 0))
+                .position(x: proxy.size.width / 2, y: proxy.size.height / 2)
+            }
+        }
+        .preferredColorScheme(.dark)
+        .onAppear {
+            if visibleDays == 0 { visibleDays = spanDays }
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            Text(title)
+                .font(.headline.weight(.bold))
+            if let summary = brushSummaryText {
+                Text(summary)
+                    .font(.caption.weight(.semibold).monospacedDigit())
+                    .foregroundStyle(tint)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.8)
+            } else {
+                Text("Drag to select a window \u{00b7} pinch or scroll to zoom")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            if brushStart != nil {
+                Button("Clear") {
+                    brushStart = nil
+                    brushEnd = nil
+                }
+                .font(.caption.weight(.bold))
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+            }
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .accessibilityLabel("Close expanded chart")
+        }
+    }
+
+    private var chartBody: some View {
+        Chart {
+            if let baselineBand {
+                RectangleMark(xStart: .value("Start", points.first?.day ?? Date()),
+                              xEnd: .value("End", points.last?.day ?? Date()),
+                              yStart: .value("Lower", baselineBand.lower),
+                              yEnd: .value("Upper", baselineBand.upper))
+                    .foregroundStyle(baselineBand.tint.opacity(0.10))
+            }
+
+            ForEach(priorPoints) { point in
+                LineMark(x: .value("Day", point.day, unit: .day),
+                         y: .value(title, point.value),
+                         series: .value("Series", "prior"))
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(.secondary.opacity(0.4))
+                    .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 4]))
+            }
+
+            ForEach(points) { point in
+                LineMark(x: .value("Day", point.day, unit: .day),
+                         y: .value(title, point.value),
+                         series: .value("Series", "current"))
+                    .interpolationMethod(.monotone)
+                    .foregroundStyle(tint)
+                PointMark(x: .value("Day", point.day, unit: .day),
+                          y: .value(title, point.value))
+                    .foregroundStyle(point.tint)
+                    .symbolSize(30)
+            }
+
+            // Event lane: real saved activity pinned to the top of the plot.
+            ForEach(events) { event in
+                PointMark(x: .value("Day", event.day, unit: .day),
+                          y: .value(title, eventLaneY))
+                    .symbol {
+                        Image(systemName: event.systemImage)
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(event.tint)
+                    }
+            }
+
+            if let start = brushStart, let end = brushEnd {
+                RectangleMark(xStart: .value("Brush start", min(start, end)),
+                              xEnd: .value("Brush end", max(start, end)))
+                    .foregroundStyle(tint.opacity(0.14))
+            }
+        }
+        .chartScrollableAxes(.horizontal)
+        .chartXVisibleDomain(length: max(1, visibleDays) * 86_400)
+        .chartXScale(domain: xDomain)
+        .chartYScale(domain: yDomain)
+        .chartOverlay { chartProxy in
+            GeometryReader { geo in
+                Rectangle()
+                    .fill(Color.clear)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 12)
+                            .onChanged { value in
+                                let plot = geo[chartProxy.plotFrame!]
+                                let startX = value.startLocation.x - plot.origin.x
+                                let currentX = value.location.x - plot.origin.x
+                                brushStart = chartProxy.value(atX: startX, as: Date.self)
+                                brushEnd = chartProxy.value(atX: currentX, as: Date.self)
+                            }
+                    )
+            }
+        }
+        .simultaneousGesture(
+            MagnificationGesture()
+                .onChanged { scale in
+                    let target = Double(spanDays) / Double(scale)
+                    visibleDays = min(max(Int(target.rounded()), 3), spanDays)
+                }
+        )
+    }
+
+    private var footer: some View {
+        HStack(spacing: 14) {
+            if !events.isEmpty {
+                Label("\(events.count) activities marked", systemImage: "flag.fill")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+            Text("\(min(visibleDays, spanDays)) of \(spanDays) days visible")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.tertiary)
+        }
+    }
+
+    /// Honest summary of the brushed window: only real points inside it.
+    private var brushSummaryText: String? {
+        guard let start = brushStart, let end = brushEnd else { return nil }
+        let lo = min(start, end), hi = max(start, end)
+        let inside = points.filter { $0.day >= lo && $0.day <= hi }
+        guard !inside.isEmpty else { return "No data in selection" }
+        let values = inside.map(\.value)
+        let avg = values.reduce(0, +) / Double(values.count)
+        let days = (Calendar.current.dateComponents([.day], from: lo, to: hi).day ?? 0) + 1
+        return String(format: "%dd \u{00b7} avg %.1f%@ \u{00b7} %.1f\u{2013}%.1f", days, avg, unit, values.min() ?? 0, values.max() ?? 0)
+    }
+
+    private var eventLaneY: Double {
+        yDomain.upperBound - (yDomain.upperBound - yDomain.lowerBound) * 0.04
+    }
+
+    /// Half-day pad each side so edge points render fully.
+    private var xDomain: ClosedRange<Date> {
+        let first = points.first?.day ?? Date()
+        let last = points.last?.day ?? Date()
+        return first.addingTimeInterval(-43_200)...last.addingTimeInterval(43_200)
+    }
+
+    private var yDomain: ClosedRange<Double> {
+        var values = points.map(\.value) + priorPoints.map(\.value)
+        if let baselineBand {
+            values.append(baselineBand.lower)
+            values.append(baselineBand.upper)
+        }
+        guard let lo = values.min(), let hi = values.max(), hi > lo else { return 0...1 }
+        let pad = (hi - lo) * 0.12
+        return (lo - pad)...(hi + pad)
+    }
+}

--- a/Atria/Atria/AtriaFaceOff.swift
+++ b/Atria/Atria/AtriaFaceOff.swift
@@ -15,6 +15,9 @@ struct AtriaFaceOffPayload: Codable, Equatable, Identifiable {
         let s: Double?
         /// Sleep hours, tenths.
         let z: Double?
+        /// Resting HR bpm (Face-Off RHR row, 2026-07-07). Optional so links
+        /// from older builds decode with nil and older builds ignore it.
+        var h: Int? = nil
     }
 
     static let currentVersion = 1
@@ -45,6 +48,12 @@ struct AtriaFaceOffPayload: Codable, Equatable, Identifiable {
         guard !values.isEmpty else { return nil }
         return values.reduce(0, +) / Double(values.count)
     }
+
+    var averageRestingHR: Int? {
+        let values = days.compactMap(\.h)
+        guard !values.isEmpty else { return nil }
+        return values.reduce(0, +) / values.count
+    }
 }
 
 enum AtriaFaceOff {
@@ -71,7 +80,8 @@ enum AtriaFaceOff {
             stats.append(AtriaFaceOffPayload.DayStat(o: offset,
                                                      r: metric.recoveryPercent,
                                                      s: strainTenths,
-                                                     z: sleepHoursTenths))
+                                                     z: sleepHoursTenths,
+                                                     h: metric.restingHR))
         }
         guard stats.contains(where: { $0.r != nil || $0.s != nil || $0.z != nil }) else { return nil }
         let cleanName = String(name.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -134,7 +144,8 @@ enum AtriaFaceOff {
             AtriaFaceOffPayload.DayStat(o: min(max(day.o, 0), 30),
                                         r: day.r.map { min(max($0, 1), 99) },
                                         s: day.s.map { min(max($0, 0), 21) },
-                                        z: day.z.map { min(max($0, 0), 16) })
+                                        z: day.z.map { min(max($0, 0), 16) },
+                                        h: day.h.map { min(max($0, 25), 120) })
         }
         return AtriaFaceOffPayload(v: raw.v,
                                    name: name.isEmpty ? "A friend" : name,
@@ -285,6 +296,12 @@ struct AtriaFaceOffView: View {
                         value: payload.averageStrain.map { String(format: "%.1f", $0) } ?? "--")
                 statRow(label: "Sleep",
                         value: payload.averageSleepHours.map { String(format: "%.1f h", $0) } ?? "--")
+                // RHR only renders when the link carried it — links from
+                // older builds simply don't show the row's value.
+                if payload.averageRestingHR != nil || mine?.averageRestingHR != nil {
+                    statRow(label: "Resting HR",
+                            value: payload.averageRestingHR.map { "\($0) bpm" } ?? "--")
+                }
                 statRow(label: "Days", value: "\(payload.days.count)")
             } else {
                 Text("Your week is still learning — wear the strap and check back.")

--- a/Atria/Atria/AtriaHealthScreen.swift
+++ b/Atria/Atria/AtriaHealthScreen.swift
@@ -934,7 +934,7 @@ private struct AtriaHealthMetricRow: View, Equatable {
         }
         }
         .frame(minHeight: 64)
-        .padding(.horizontal, 12)
+        .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(Color(uiColor: .tertiarySystemGroupedBackground),
                     in: RoundedRectangle(cornerRadius: 8, style: .continuous))

--- a/Atria/Atria/AtriaHealthScreen.swift
+++ b/Atria/Atria/AtriaHealthScreen.swift
@@ -89,6 +89,7 @@ struct AtriaHealthScreen: View {
             AtriaMetricDetailSheet(metric: detail,
                                    rollups: store.dailyRollupHistory,
                                    confirmedWorkouts: store.confirmedWorkouts,
+                                   behaviorImpacts: store.behaviorImpactSummariesCache,
                                    baseline: AtriaBaselineTargetSnapshot(store.baseline),
                                    sleepHistory: store.sleepHistorySnapshot,
                                    guidance: heroStore.state.guidance,

--- a/Atria/Atria/AtriaHistorySection.swift
+++ b/Atria/Atria/AtriaHistorySection.swift
@@ -541,6 +541,7 @@ struct AtriaDetectionsListSheet: View {
     /// the Adjust routing only exists when a store is present.
     var store: SessionStore? = nil
     @State private var adjustmentNight: SleepHistorySnapshot.Night?
+    @State private var addWorkoutSeed: DetectionEvent?
 
     var body: some View {
         NavigationStack {
@@ -570,6 +571,23 @@ struct AtriaDetectionsListSheet: View {
                                     }
                                     .atriaCardAction(prominent: false, tint: Metrics.electricSleep)
                                 }
+                            } else if isSaveableWorkout(event) {
+                                // Workout rows became actionable once events
+                                // carry their real window (2026-07-07):
+                                // detected-but-unsaved windows offer a
+                                // pre-filled save; anything without a window
+                                // or already saved stays a plain log row.
+                                VStack(alignment: .leading, spacing: 8) {
+                                    AtriaDetectionRow(event: event)
+                                    Button {
+                                        addWorkoutSeed = event
+                                    } label: {
+                                        Label("Save as workout", systemImage: "plus.circle")
+                                            .font(.caption.weight(.semibold))
+                                            .frame(maxWidth: .infinity, minHeight: 32)
+                                    }
+                                    .atriaCardAction(prominent: false, tint: Metrics.electricStrain)
+                                }
                             } else {
                                 AtriaDetectionRow(event: event)
                             }
@@ -579,6 +597,15 @@ struct AtriaDetectionsListSheet: View {
                 .padding(16)
             }
             .navigationTitle("Detections")
+            .sheet(item: $addWorkoutSeed) { event in
+                if let store {
+                    AtriaAddWorkoutSheet(store: store,
+                                         initialStart: event.windowStart,
+                                         initialEnd: event.windowEnd)
+                        .presentationDetents([.medium, .large])
+                        .presentationDragIndicator(.visible)
+                }
+            }
             .sheet(item: $adjustmentNight) { night in
                 if let store {
                     AtriaManualSleepSheet(initialStart: night.start,
@@ -607,6 +634,19 @@ struct AtriaDetectionsListSheet: View {
     /// is unambiguous: auto-confirms fire shortly after the night ends, so a
     /// night qualifies when the event lands within [end - 1h, end + 12h] —
     /// and exactly ONE night may qualify.
+    /// A workout detection is saveable when it carries its real window, the
+    /// store is present, and no confirmed workout already overlaps that
+    /// window (those were either saved from review or would duplicate).
+    private func isSaveableWorkout(_ event: DetectionEvent) -> Bool {
+        guard event.kind == "workoutDetected",
+              event.reason != "confirmed",
+              let start = event.windowStart,
+              let end = event.windowEnd,
+              end > start,
+              let store else { return false }
+        return !store.confirmedWorkouts.contains { $0.end > start && $0.start < end }
+    }
+
     private func uniqueNight(for event: DetectionEvent) -> SleepHistorySnapshot.Night? {
         guard let store, event.kind == "sleepAutoConfirmed" else { return nil }
         let matches = store.sleepHistorySnapshot.nights.filter { night in

--- a/Atria/Atria/AtriaHomeView.swift
+++ b/Atria/Atria/AtriaHomeView.swift
@@ -2748,7 +2748,12 @@ struct AtriaHomeView: View {
                          hrImportStatus: $hrImportStatus,
                          hapticSettings: $hapticSettings,
                          officialAppInstalled: officialAppInstalled,
-                         developerModeEnabled: developerModeEnabled)
+                         developerModeEnabled: developerModeEnabled,
+                         onShowConnectionGuide: {
+                             showStrapScreen = false
+                             connectionGuideSnoozedUntil = nil
+                             showConnectionGuide = true
+                         })
     }
 
     private var researchValidationContent: some View {

--- a/Atria/Atria/AtriaHomeView.swift
+++ b/Atria/Atria/AtriaHomeView.swift
@@ -2041,7 +2041,10 @@ struct AtriaHomeView: View {
                             .id(Self.debugDashboardScrollBottomID)
                     }
                     .frame(maxWidth: contentWidth)
-                    .padding(.horizontal, 16)
+                    // 12pt gutter (user feedback 2026-07-07: "a lot of unused
+                    // space on the sides" — three inset layers stacked to
+                    // 44-46pt/side; this is the shared knob).
+                    .padding(.horizontal, 12)
                     .padding(.top, 12)
                     .padding(.bottom, scrollBottomClearance)
                     .frame(maxWidth: .infinity)

--- a/Atria/Atria/AtriaJournalTab.swift
+++ b/Atria/Atria/AtriaJournalTab.swift
@@ -17,7 +17,7 @@ struct AtriaJournalTab: View {
             // visualizes (UX audit 2026-07-07) instead of orphaned mid-stack.
             AtriaJournalHeatStrip(entries: store.behaviorJournalEntries)
             AtriaRoutineCard(store: store)
-            AtriaJournalCycleCard()
+            AtriaJournalCycleCard(sessionStore: store)
         }
     }
 }
@@ -29,6 +29,9 @@ struct AtriaJournalTab: View {
 /// explicit, one-tap opt-in from here, never implied by anything else in the
 /// app.
 private struct AtriaJournalCycleCard: View {
+    /// Recovery history for the phase-patterns rows (design backlog item 10).
+    let sessionStore: SessionStore
+
     // Dotted UserDefaults key: must use @AtriaDefault, not @AppStorage — see
     // AtriaDefault.swift for why plain @AppStorage on a dotted key storms the
     // whole view tree under high-frequency sibling writes.
@@ -36,12 +39,50 @@ private struct AtriaJournalCycleCard: View {
     @StateObject private var store = AtriaCycleTrackingStore()
     @State private var showLogSheet = false
 
+    /// Cycle-phase patterns (design backlog item 10): average recovery per
+    /// estimated phase over the trailing 90 days. Gated on a PERSONALIZED
+    /// estimate (>=2 completed cycles) and >=3 classified days per phase;
+    /// always labeled an estimate/association per the honesty rules.
+    @ViewBuilder
+    private var phasePatternRows: some View {
+        let patterns = store.recoveryPatternsByPhase(
+            days: sessionStore.dailyRollupHistory.map { (day: $0.day, recovery: $0.recovery) })
+        if !patterns.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("RECOVERY BY PHASE (ESTIMATE)")
+                    .font(.caption2.weight(.black))
+                    .foregroundStyle(.tertiary)
+                    .kerning(0.8)
+                ForEach(patterns, id: \.phase) { pattern in
+                    HStack {
+                        Text(pattern.phase.title)
+                            .font(.caption.weight(.semibold))
+                        Spacer(minLength: 8)
+                        Text("\(pattern.averageRecovery)% avg")
+                            .font(.caption.weight(.bold).monospacedDigit())
+                            .foregroundStyle(Metrics.recoveryColor(pattern.averageRecovery))
+                        Text("\u{00B7} \(pattern.dayCount)d")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Text("Averages across your last 90 days, grouped by estimated phase. An association from your logs, not a prediction.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(12)
+            .atriaInsetCard(tint: .pink)
+        }
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             AtriaPanelSectionHeader(title: "Cycle",
                                     subtitle: isEnabled ? "Phase estimate from your logged dates" : "Optional, off by default")
             if isEnabled {
                 enabledContent
+                phasePatternRows
             } else {
                 disabledContent
             }

--- a/Atria/Atria/AtriaLiveWorkoutView.swift
+++ b/Atria/Atria/AtriaLiveWorkoutView.swift
@@ -508,12 +508,8 @@ struct AtriaLiveWorkoutView: View {
                     Text(coachCueTitle)
                         .font(.headline.weight(.black))
                         .foregroundStyle(.white)
-                    Text("Z\(zone.rawValue)")
-                        .font(.caption.weight(.black).monospacedDigit())
-                        .foregroundStyle(zone.color)
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(zone.color.opacity(0.16), in: Capsule())
+                    // Zone chip removed (dedup audit): the zone bar's chip
+                    // and the hero caption already state the current zone.
                 }
 
                 Text(coachCueDetail)
@@ -614,12 +610,8 @@ struct AtriaLiveWorkoutView: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("Set workout target. Currently \(targetSourceLabel).")
-                Text(strainTargetValueText)
-                    .font(.caption.weight(.bold).monospacedDigit())
-                    .foregroundStyle(Metrics.electricStrain)
-                    .padding(.horizontal, 9)
-                    .padding(.vertical, 5)
-                    .background(Metrics.electricStrain.opacity(0.16), in: Capsule())
+                // Header value capsule removed (dedup audit 2026-07-07): the
+                // labeled Target pill below is the single copy.
             }
 
             GeometryReader { proxy in
@@ -643,7 +635,9 @@ struct AtriaLiveWorkoutView: View {
             .accessibilityHidden(true)
 
             HStack(spacing: 8) {
-                focusPill(title: "Now", value: String(format: "%.1f", strain))
+                // "Now" pill removed (dedup audit): the stats row's Strain
+                // tile is the single live-strain readout; the progress bar
+                // here shows position vs target.
                 focusPill(title: "Target", value: strainTargetValueText)
                 focusPill(title: "Cue", value: strainTargetCue)
             }

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6601,6 +6601,8 @@ struct AtriaMetricDetailSheet: View {
     // AtriaOverviewReadinessSection screens) keep compiling unchanged.
     let hrZoneMinutes: TodayHRZoneMinutes
     let maxHeartRate: Int?
+    private let rollups: [DailyRollupStoreEntry]
+    @State private var openedHistoryDay: AtriaHistoryDay?
     let vo2MaxEstimate: VO2MaxEstimateSummary?
     let skinTemperatureDeviation: IMUAuditSummary.SkinTemperatureDeviationSummary?
     private let preparedHistory: AtriaPreparedMetricHistory
@@ -6639,6 +6641,7 @@ struct AtriaMetricDetailSheet: View {
         self.maxHeartRate = maxHeartRate
         self.vo2MaxEstimate = vo2MaxEstimate
         self.skinTemperatureDeviation = skinTemperatureDeviation
+        self.rollups = rollups
         self.preparedHistory = AtriaPreparedMetricHistory(rollups: rollups, baseline: baseline, sleepGoalHours: sleepGoalHours)
     }
 
@@ -6669,6 +6672,14 @@ struct AtriaMetricDetailSheet: View {
                                     recoveryEstimate: recoveryEstimate,
                                     sleepGoalHours: sleepGoalHours)
         }
+        .sheet(item: $openedHistoryDay) { day in
+            AtriaHistoryDayDetailSheet(day: day,
+                                       medians: AtriaHistoryModel.make(rollups: rollups,
+                                                                       workouts: confirmedWorkouts,
+                                                                       sleeps: []).medianWindow(around: day))
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        }
     }
 
     @ViewBuilder
@@ -6697,7 +6708,8 @@ struct AtriaMetricDetailSheet: View {
                                 accessibilitySummary: "Recovery over \(range.label).",
                                 priorPoints: preparedHistory.recoveryPrior[range] ?? [],
                                 companions: [("That day's HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? []),
-                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])])
+                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])],
+                                onOpenDay: { day in openHistoryDay(for: day) })
                 }
             } about: {
                 aboutDisclosure
@@ -6726,7 +6738,8 @@ struct AtriaMetricDetailSheet: View {
                                 emptyExplanation: "HRV is read from steady overnight wear — each clean night adds a point here.",
                                 priorPoints: preparedHistory.hrvPrior[range] ?? [],
                                 companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
-                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])])
+                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])],
+                                onOpenDay: { day in openHistoryDay(for: day) })
                 }
             } about: {
                 aboutDisclosure
@@ -6755,7 +6768,8 @@ struct AtriaMetricDetailSheet: View {
                                 emptyExplanation: "Resting heart rate is read from overnight wear — each night adds a point here.",
                                 priorPoints: preparedHistory.restingHeartRatePrior[range] ?? [],
                                 companions: [("That day's HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? []),
-                                             ("Recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? [])])
+                                             ("Recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? [])],
+                                onOpenDay: { day in openHistoryDay(for: day) })
                 }
             } about: {
                 aboutDisclosure
@@ -6813,7 +6827,8 @@ struct AtriaMetricDetailSheet: View {
                                 accessibilitySummary: "Sleep duration over \(range.label).",
                                 priorPoints: preparedHistory.sleepPrior[range] ?? [],
                                 companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
-                                             ("HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? [])])
+                                             ("HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? [])],
+                                onOpenDay: { day in openHistoryDay(for: day) })
                 }
             } about: {
                 aboutDisclosure
@@ -6843,7 +6858,8 @@ struct AtriaMetricDetailSheet: View {
                                 accessibilitySummary: "Strain over \(range.label).",
                                 priorPoints: preparedHistory.strainPrior[range] ?? [],
                                 companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
-                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])])
+                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])],
+                                onOpenDay: { day in openHistoryDay(for: day) })
                 }
             } about: {
                 aboutDisclosure
@@ -7449,7 +7465,8 @@ struct AtriaMetricDetailSheet: View {
                              accessibilitySummary: String,
                              emptyExplanation: String? = nil,
                              priorPoints: [AtriaDetailChartPoint] = [],
-                             companions: [(title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint])] = []) -> some View {
+                             companions: [(title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint])] = [],
+                             onOpenDay: ((Date) -> Void)? = nil) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Text(title)
@@ -7628,6 +7645,13 @@ struct AtriaMetricDetailSheet: View {
                 // Guarantee the plot can never bleed past its frame in any data
                 // state (matches AtriaTrendChartCard's clip).
                 .clipped()
+                // Double-tap opens the scrubbed day (design handoff Graph
+                // Interactions). Without a selection it does nothing; never a guessed day.
+                .onTapGesture(count: 2) {
+                    if let target = scrubbedDay, let onOpenDay {
+                        onOpenDay(target)
+                    }
+                }
                 .accessibilityLabel(accessibilitySummary)
 
                 if points.first(where: { $0.bandLower != nil }) != nil {
@@ -7646,6 +7670,12 @@ struct AtriaMetricDetailSheet: View {
                 // is selected, sibling metrics for THAT day appear beneath the
                 // chart. A companion with no real value that day shows nothing
                 // for it (fail closed, never interpolated).
+                if scrubbedDay != nil, onOpenDay != nil {
+                    Text("Double-tap the chart to open this day")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+
                 if let target = scrubbedDay, !companions.isEmpty {
                     HStack(spacing: 8) {
                         ForEach(Array(companions.enumerated()), id: \.offset) { _, companion in
@@ -7687,6 +7717,16 @@ struct AtriaMetricDetailSheet: View {
             values.append(comparison.priorAverage)
         }
         return AtriaTrendChartScale.domain(values: values)
+    }
+
+    /// Double-tap route: resolve the scrubbed date to its history-day model
+    /// and open the existing day-vs-median sheet. Unknown day: does nothing.
+    private func openHistoryDay(for date: Date) {
+        let model = AtriaHistoryModel.make(rollups: rollups,
+                                           workouts: confirmedWorkouts,
+                                           sleeps: [])
+        guard let day = model.days.first(where: { Calendar.current.isDate($0.date, inSameDayAs: date) }) else { return }
+        openedHistoryDay = day
     }
 
     private func latestText(value: Double, unit: String) -> String {

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -7286,7 +7286,13 @@ struct AtriaMetricDetailSheet: View {
         return [
             AtriaMetricContributorRow(systemImage: "moon.fill",
                                       name: "Performance",
-                                      value: latest?.durationText ?? "--",
+                                      // Dedup audit 2026-07-07: this row's
+                                      // value was the duration (shown 3 more
+                                      // times on this sheet); it now shows
+                                      // the performance % its name promises.
+                                      value: latest.map {
+                                          "\(sleepHistory.sleepPerformancePercent(for: $0, baseNeedHours: sleepBaseNeedHours, yesterdayStrain: yesterdayStrainForLatestNight))%"
+                                      } ?? "--",
                                       comparison: latest.map {
                                           sleepHistory.sleepPerformanceSummary(for: $0,
                                                                                baseNeedHours: sleepBaseNeedHours,
@@ -9969,18 +9975,11 @@ private struct AtriaSleepHypnogramCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            HStack {
-                Text("Sleep estimate")
-                    .font(.subheadline.weight(.semibold))
-                    .lineLimit(1)
-                Spacer()
-                Text(night.durationText)
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.cyan)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.75)
-                    .layoutPriority(1)
-            }
+            // Header duration removed (dedup audit 2026-07-07): the sheet
+            // hero owns the duration readout.
+            Text("Sleep estimate")
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
 
             if night.displayStageSegments.isEmpty {
                 Text("Stages are still building. Atria labels this as a heart-rate and motion estimate, not EEG.")
@@ -10005,14 +10004,11 @@ private struct AtriaSleepHypnogramCard: View {
                     .foregroundStyle(.secondary)
             }
 
-            HStack(spacing: 10) {
-                metricPill(title: "Performance",
-                           value: sleepPerformanceText)
-                metricPill(title: "Consistency",
-                           value: sleepConsistencyText)
-            }
-
-            Text("Slept \(night.durationText) of \(AtriaMetricFormat.sleepHours(neededHours)) needed · \(sleepPerformanceText)")
+            // Performance/Consistency pills removed (dedup audit): the
+            // contributor rows below the chart own both values. The footer
+            // keeps only the need context — duration and performance live
+            // on the hero.
+            Text("Needed \(AtriaMetricFormat.sleepHours(neededHours)) last night")
                 .font(.caption.weight(.medium))
                 .foregroundStyle(.secondary)
 

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -7413,13 +7413,9 @@ struct AtriaMetricDetailSheet: View {
     }
 
     private var strainContributorRows: [AtriaMetricContributorRow] {
-        let latest = preparedHistory.latestStrain[range]
+        // "Day strain" row removed (dedup audit 2026-07-07): the hero and
+        // the gauge already show the value; the Target row owns the target.
         return [
-            AtriaMetricContributorRow(systemImage: "flame.fill",
-                                      name: "Day strain",
-                                      value: latest.map { String(format: "%.1f", $0) } ?? "--",
-                                      comparison: guidance.target.map { String(format: "target %.1f", $0) } ?? "target building",
-                                      direction: 0),
             AtriaMetricContributorRow(systemImage: "target",
                                       name: "Target",
                                       value: guidance.target.map { String(format: "%.1f", $0) } ?? "--",
@@ -7598,16 +7594,10 @@ struct AtriaMetricDetailSheet: View {
         // check and the ForEach below.
         let workouts = todayConfirmedWorkouts
         return VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .firstTextBaseline) {
-                Text("Workouts")
-                    .font(.subheadline.weight(.semibold))
-                Spacer(minLength: 0)
-                Text(guidance.target.map { String(format: "Target %.1f", $0) } ?? "Target building")
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(Metrics.electricStrain)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.72)
-            }
+            // Header target capsule removed (dedup audit 2026-07-07): the
+            // Target contributor row is the single textual copy.
+            Text("Workouts")
+                .font(.subheadline.weight(.semibold))
 
             if workouts.isEmpty {
                 Label("No confirmed workouts today", systemImage: "figure.run")

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6642,6 +6642,7 @@ struct AtriaMetricDetailSheet: View {
     // AtriaOverviewReadinessSection screens) keep compiling unchanged.
     let hrZoneMinutes: TodayHRZoneMinutes
     let maxHeartRate: Int?
+    let behaviorImpacts: [BehaviorImpactSummary]
     private let rollups: [DailyRollupStoreEntry]
     @State private var openedHistoryDay: AtriaHistoryDay?
     @State private var showChartOptions = false
@@ -6660,6 +6661,7 @@ struct AtriaMetricDetailSheet: View {
     init(metric: AtriaMetricDetailKind,
          rollups: [DailyRollupStoreEntry],
          confirmedWorkouts: [UserConfirmedWorkout] = [],
+         behaviorImpacts: [BehaviorImpactSummary] = [],
          baseline: AtriaBaselineTargetSnapshot,
          sleepHistory: SleepHistorySnapshot,
          guidance: Coach.Guidance,
@@ -6691,6 +6693,7 @@ struct AtriaMetricDetailSheet: View {
         self.vo2MaxEstimate = vo2MaxEstimate
         self.skinTemperatureDeviation = skinTemperatureDeviation
         self.rollups = rollups
+        self.behaviorImpacts = behaviorImpacts
         self.preparedHistory = AtriaPreparedMetricHistory(rollups: rollups, baseline: baseline, sleepGoalHours: sleepGoalHours)
     }
 
@@ -6775,6 +6778,7 @@ struct AtriaMetricDetailSheet: View {
                                       heroState: recoveryHeroState,
                                       tint: recoveryEstimate.percent.map(Metrics.recoveryColor) ?? Metrics.electricGreen) {
                 contributorCard
+                behaviorsMoveYouCard
             } contributors: {
                 EmptyView()
             } chart: {
@@ -7991,6 +7995,27 @@ struct AtriaMetricDetailSheet: View {
                     preparedHistory.strainPrior[range] ?? [], nil)
         default:
             return nil
+        }
+    }
+
+    /// "Behaviors that move you" (design backlog item 7): the Journal's
+    /// statistically-gated behavior impacts (Welch p < 0.10, ≥5 logged and
+    /// comparison days, ≥3% effect) surfaced where the recovery number
+    /// lives. Reuses the exact rows the Journal renders — one engine.
+    @ViewBuilder
+    private var behaviorsMoveYouCard: some View {
+        if !behaviorImpacts.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Behaviors that move you")
+                    .font(.subheadline.weight(.semibold))
+                AtriaJournalBehaviorImpactRows(impacts: Array(behaviorImpacts.prefix(3)))
+                Text("From your journal tags vs next-day recovery over 90 days. Association, not proof of cause.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(14)
+            .atriaInsetCard(tint: Metrics.electricGreen)
         }
     }
 
@@ -11171,7 +11196,7 @@ private struct AtriaJournalImpactStrip: View, Equatable {
     }
 }
 
-private struct AtriaJournalBehaviorImpactRows: View, Equatable {
+struct AtriaJournalBehaviorImpactRows: View, Equatable {
     let impacts: [BehaviorImpactSummary]
 
     var body: some View {

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6603,6 +6603,9 @@ struct AtriaMetricDetailSheet: View {
     let maxHeartRate: Int?
     private let rollups: [DailyRollupStoreEntry]
     @State private var openedHistoryDay: AtriaHistoryDay?
+    @State private var showChartOptions = false
+    @State private var bucketOverride: AtriaChartBucketOverride
+    @State private var showMinMaxBand: Bool
     let vo2MaxEstimate: VO2MaxEstimateSummary?
     let skinTemperatureDeviation: IMUAuditSummary.SkinTemperatureDeviationSummary?
     private let preparedHistory: AtriaPreparedMetricHistory
@@ -6626,9 +6629,13 @@ struct AtriaMetricDetailSheet: View {
          vo2MaxEstimate: VO2MaxEstimateSummary? = nil,
          skinTemperatureDeviation: IMUAuditSummary.SkinTemperatureDeviationSummary? = nil,
          initialRange: AtriaTrendRange = .month,
-         initialScrubbedDay: Date? = nil) {
+         initialScrubbedDay: Date? = nil,
+         initialBucketOverride: AtriaChartBucketOverride = .auto,
+         initialShowMinMaxBand: Bool = true) {
         _range = State(initialValue: initialRange)
         _scrubbedDay = State(initialValue: initialScrubbedDay)
+        _bucketOverride = State(initialValue: initialBucketOverride)
+        _showMinMaxBand = State(initialValue: initialShowMinMaxBand)
         self.metric = metric
         self.confirmedWorkouts = confirmedWorkouts
         self.baseline = baseline
@@ -6651,6 +6658,20 @@ struct AtriaMetricDetailSheet: View {
                 HStack(alignment: .top, spacing: 12) {
                     AtriaPanelSectionHeader(title: metric.title, subtitle: "Trend and context")
                     Spacer(minLength: 0)
+                    if chartSupportsOptions {
+                        Button {
+                            showChartOptions = true
+                        } label: {
+                            // chart.bar.xaxis (not the slider glyph — that
+                            // bare literal is banned by the removed-customize
+                            // guard in this file).
+                            Image(systemName: "chart.bar.xaxis")
+                                .font(.headline.weight(.semibold))
+                                .padding(10)
+                                .background(.quaternary.opacity(0.22), in: Circle())
+                        }
+                        .accessibilityLabel("Chart options: bucketing and min-max band")
+                    }
                     Button {
                         showingMeaningSheet = true
                     } label: {
@@ -6671,6 +6692,12 @@ struct AtriaMetricDetailSheet: View {
                                     guidance: guidance,
                                     recoveryEstimate: recoveryEstimate,
                                     sleepGoalHours: sleepGoalHours)
+        }
+        .sheet(isPresented: $showChartOptions) {
+            AtriaChartOptionsSheet(bucketOverride: $bucketOverride,
+                                   showMinMaxBand: $showMinMaxBand)
+                .presentationDetents([.height(300)])
+                .presentationDragIndicator(.visible)
         }
         .sheet(item: $openedHistoryDay) { day in
             AtriaHistoryDayDetailSheet(day: day,
@@ -6701,7 +6728,7 @@ struct AtriaMetricDetailSheet: View {
                     metricChart(title: "Recovery",
                                 unit: "%",
                                 tint: Metrics.electricGreen,
-                                points: preparedHistory.recovery[range] ?? [],
+                                points: displayedPoints(auto: preparedHistory.recovery[range] ?? [], raw: preparedHistory.recoveryRaw[range] ?? []),
                                 summary: preparedHistory.recoverySummary[range],
                                 comparison: preparedHistory.recoveryComparison[range],
                                 baselineBand: nil,
@@ -6730,7 +6757,7 @@ struct AtriaMetricDetailSheet: View {
                     metricChart(title: "HRV",
                                 unit: "ms",
                                 tint: metric.tint,
-                                points: preparedHistory.hrv[range] ?? [],
+                                points: displayedPoints(auto: preparedHistory.hrv[range] ?? [], raw: preparedHistory.hrvRaw[range] ?? []),
                                 summary: preparedHistory.hrvSummary[range],
                                 comparison: preparedHistory.hrvComparison[range],
                                 baselineBand: hrvBand,
@@ -6760,7 +6787,7 @@ struct AtriaMetricDetailSheet: View {
                     metricChart(title: "Resting HR",
                                 unit: "bpm",
                                 tint: metric.tint,
-                                points: preparedHistory.restingHeartRate[range] ?? [],
+                                points: displayedPoints(auto: preparedHistory.restingHeartRate[range] ?? [], raw: preparedHistory.restingHeartRateRaw[range] ?? []),
                                 summary: preparedHistory.restingHeartRateSummary[range],
                                 comparison: preparedHistory.restingHeartRateComparison[range],
                                 baselineBand: restingBand,
@@ -6790,7 +6817,7 @@ struct AtriaMetricDetailSheet: View {
                     metricChart(title: "Respiratory rate",
                                 unit: "/min",
                                 tint: metric.tint,
-                                points: preparedHistory.respiratoryRate[range] ?? [],
+                                points: displayedPoints(auto: preparedHistory.respiratoryRate[range] ?? [], raw: preparedHistory.respiratoryRateRaw[range] ?? []),
                                 summary: preparedHistory.respiratoryRateSummary[range],
                                 comparison: preparedHistory.respiratoryRateComparison[range],
                                 baselineBand: respiratoryBand,
@@ -6820,7 +6847,7 @@ struct AtriaMetricDetailSheet: View {
                     metricChart(title: "Sleep duration",
                                 unit: "h",
                                 tint: Metrics.electricSleep,
-                                points: preparedHistory.sleep[range] ?? [],
+                                points: displayedPoints(auto: preparedHistory.sleep[range] ?? [], raw: preparedHistory.sleepRaw[range] ?? []),
                                 summary: preparedHistory.sleepSummary[range],
                                 comparison: preparedHistory.sleepComparison[range],
                                 baselineBand: nil,
@@ -6851,7 +6878,7 @@ struct AtriaMetricDetailSheet: View {
                     metricChart(title: "Strain",
                                 unit: "",
                                 tint: Metrics.electricStrain,
-                                points: preparedHistory.strain[range] ?? [],
+                                points: displayedPoints(auto: preparedHistory.strain[range] ?? [], raw: preparedHistory.strainRaw[range] ?? []),
                                 summary: preparedHistory.strainSummary[range],
                                 comparison: preparedHistory.strainComparison[range],
                                 baselineBand: nil,
@@ -7717,6 +7744,30 @@ struct AtriaMetricDetailSheet: View {
             values.append(comparison.priorAverage)
         }
         return AtriaTrendChartScale.domain(values: values)
+    }
+
+    private var chartSupportsOptions: Bool {
+        switch metric {
+        case .recovery, .hrv, .restingHeartRate, .respiratoryRate, .sleep, .strain: return true
+        default: return false
+        }
+    }
+
+    /// Applies the manual bucket override from the chart-options sheet.
+    /// .auto returns the precomputed series (weekly above 90 days); .daily
+    /// returns raw points; .weeklyAverage forces weekly buckets. The min-max
+    /// band toggle strips bands at display time.
+    private func displayedPoints(auto: [AtriaDetailChartPoint],
+                                 raw: [AtriaDetailChartPoint]) -> [AtriaDetailChartPoint] {
+        let base: [AtriaDetailChartPoint]
+        switch bucketOverride {
+        case .auto: base = auto
+        case .daily: base = raw
+        case .weeklyAverage:
+            base = AtriaPreparedMetricHistory.bucketedForDisplay(raw, range: range, calendar: .current, forceWeekly: true)
+        }
+        guard !showMinMaxBand else { return base }
+        return base.map { AtriaDetailChartPoint(day: $0.day, value: $0.value, tint: $0.tint) }
     }
 
     /// Double-tap route: resolve the scrubbed date to its history-day model
@@ -9437,6 +9488,14 @@ private struct AtriaPreparedMetricHistory {
     let respiratoryRatePrior: [AtriaTrendRange: [AtriaDetailChartPoint]]
     let sleepPrior: [AtriaTrendRange: [AtriaDetailChartPoint]]
     let strainPrior: [AtriaTrendRange: [AtriaDetailChartPoint]]
+    // RAW (unbucketed) series for the manual bucket override in the chart
+    // options sheet (design handoff "Range & interval", 2026-07-07).
+    let recoveryRaw: [AtriaTrendRange: [AtriaDetailChartPoint]]
+    let hrvRaw: [AtriaTrendRange: [AtriaDetailChartPoint]]
+    let restingHeartRateRaw: [AtriaTrendRange: [AtriaDetailChartPoint]]
+    let respiratoryRateRaw: [AtriaTrendRange: [AtriaDetailChartPoint]]
+    let sleepRaw: [AtriaTrendRange: [AtriaDetailChartPoint]]
+    let strainRaw: [AtriaTrendRange: [AtriaDetailChartPoint]]
     let latestStrain: [AtriaTrendRange: Double]
     let recoverySummary: [AtriaTrendRange: AtriaDetailPeriodSummary]
     let hrvSummary: [AtriaTrendRange: AtriaDetailPeriodSummary]
@@ -9472,10 +9531,11 @@ private struct AtriaPreparedMetricHistory {
     /// the metric's own zone coloring still applies). Short ranges and sparse
     /// series pass through untouched. Summaries/comparisons stay computed
     /// from raw daily points (2026-07-07 design handoff).
-    private static func bucketedForDisplay(_ points: [AtriaDetailChartPoint],
-                                           range: AtriaTrendRange,
-                                           calendar: Calendar) -> [AtriaDetailChartPoint] {
-        guard range.days > 90, points.count > 60 else { return points }
+    static func bucketedForDisplay(_ points: [AtriaDetailChartPoint],
+                                   range: AtriaTrendRange,
+                                   calendar: Calendar,
+                                   forceWeekly: Bool = false) -> [AtriaDetailChartPoint] {
+        guard forceWeekly || (range.days > 90 && points.count > 60) else { return points }
         var buckets: [Date: [AtriaDetailChartPoint]] = [:]
         for point in points {
             let weekStart = calendar.dateInterval(of: .weekOfYear, for: point.day)?.start
@@ -9523,6 +9583,12 @@ private struct AtriaPreparedMetricHistory {
         var respiratoryPriorByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
         var sleepPriorByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
         var strainPriorByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
+        var recoveryRawByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
+        var hrvRawByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
+        var restingRawByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
+        var respiratoryRawByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
+        var sleepRawByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
+        var strainRawByRange: [AtriaTrendRange: [AtriaDetailChartPoint]] = [:]
         var latestStrainByRange: [AtriaTrendRange: Double] = [:]
         var recoverySummaryByRange: [AtriaTrendRange: AtriaDetailPeriodSummary] = [:]
         var hrvSummaryByRange: [AtriaTrendRange: AtriaDetailPeriodSummary] = [:]
@@ -9566,6 +9632,7 @@ private struct AtriaPreparedMetricHistory {
                 item.recovery.map { AtriaDetailChartPoint(day: item.day, value: Double($0), tint: Metrics.recoveryColor($0)) }
             }
             recoveryByRange[range] = Self.bucketedForDisplay(recoveryPoints, range: range, calendar: calendar)
+            recoveryRawByRange[range] = recoveryPoints
             recoveryPriorByRange[range] = Self.ghostSeries(priorRecoveryPoints, range: range, calendar: calendar)
             recoverySummaryByRange[range] = AtriaDetailPeriodSummary(points: recoveryPoints, unit: "%")
             recoveryComparisonByRange[range] = AtriaDetailComparisonSummary(current: recoveryPoints, prior: priorRecoveryPoints, unit: "%")
@@ -9585,6 +9652,7 @@ private struct AtriaPreparedMetricHistory {
                                              tint: Self.hrvTint(value: value, baseline: baseline))
             }
             hrvByRange[range] = Self.bucketedForDisplay(hrvPoints, range: range, calendar: calendar)
+            hrvRawByRange[range] = hrvPoints
             hrvPriorByRange[range] = Self.ghostSeries(priorHRVPoints, range: range, calendar: calendar)
             hrvSummaryByRange[range] = AtriaDetailPeriodSummary(points: hrvPoints, unit: "ms")
             hrvComparisonByRange[range] = AtriaDetailComparisonSummary(current: hrvPoints, prior: priorHRVPoints, unit: "ms")
@@ -9602,6 +9670,7 @@ private struct AtriaPreparedMetricHistory {
                                              tint: Self.restingTint(value: value, baseline: baseline))
             }
             restingByRange[range] = Self.bucketedForDisplay(restingPoints, range: range, calendar: calendar)
+            restingRawByRange[range] = restingPoints
             restingPriorByRange[range] = Self.ghostSeries(priorRestingPoints, range: range, calendar: calendar)
             restingSummaryByRange[range] = AtriaDetailPeriodSummary(points: restingPoints, unit: "bpm")
             restingComparisonByRange[range] = AtriaDetailComparisonSummary(current: restingPoints, prior: priorRestingPoints, unit: "bpm")
@@ -9613,6 +9682,7 @@ private struct AtriaPreparedMetricHistory {
                 item.respiratoryRate.map { AtriaDetailChartPoint(day: item.day, value: $0, tint: .teal) }
             }
             respiratoryByRange[range] = Self.bucketedForDisplay(respiratoryPoints, range: range, calendar: calendar)
+            respiratoryRawByRange[range] = respiratoryPoints
             respiratoryPriorByRange[range] = Self.ghostSeries(priorRespiratoryPoints, range: range, calendar: calendar)
             respiratorySummaryByRange[range] = AtriaDetailPeriodSummary(points: respiratoryPoints, unit: "/min")
             respiratoryComparisonByRange[range] = AtriaDetailComparisonSummary(current: respiratoryPoints, prior: priorRespiratoryPoints, unit: "/min")
@@ -9635,6 +9705,7 @@ private struct AtriaPreparedMetricHistory {
                 return AtriaDetailChartPoint(day: item.day, value: hours, tint: tint)
             }
             sleepByRange[range] = Self.bucketedForDisplay(sleepPoints, range: range, calendar: calendar)
+            sleepRawByRange[range] = sleepPoints
             sleepPriorByRange[range] = Self.ghostSeries(priorSleepPoints, range: range, calendar: calendar)
             sleepSummaryByRange[range] = AtriaDetailPeriodSummary(points: sleepPoints, unit: "h")
             sleepComparisonByRange[range] = AtriaDetailComparisonSummary(current: sleepPoints, prior: priorSleepPoints, unit: "h")
@@ -9646,6 +9717,7 @@ private struct AtriaPreparedMetricHistory {
                 item.strain.map { AtriaDetailChartPoint(day: item.day, value: $0, tint: Metrics.electricStrain) }
             }
             strainByRange[range] = Self.bucketedForDisplay(strainPoints, range: range, calendar: calendar)
+            strainRawByRange[range] = strainPoints
             strainPriorByRange[range] = Self.ghostSeries(priorStrainPoints, range: range, calendar: calendar)
             strainSummaryByRange[range] = AtriaDetailPeriodSummary(points: strainPoints, unit: "")
             strainComparisonByRange[range] = AtriaDetailComparisonSummary(current: strainPoints, prior: priorStrainPoints, unit: "")
@@ -9692,6 +9764,12 @@ private struct AtriaPreparedMetricHistory {
         self.respiratoryRatePrior = respiratoryPriorByRange
         self.sleepPrior = sleepPriorByRange
         self.strainPrior = strainPriorByRange
+        self.recoveryRaw = recoveryRawByRange
+        self.hrvRaw = hrvRawByRange
+        self.restingHeartRateRaw = restingRawByRange
+        self.respiratoryRateRaw = respiratoryRawByRange
+        self.sleepRaw = sleepRawByRange
+        self.strainRaw = strainRawByRange
         self.latestStrain = latestStrainByRange
         self.recoverySummary = recoverySummaryByRange
         self.hrvSummary = hrvSummaryByRange
@@ -11954,5 +12032,76 @@ private struct AtriaDisconnectedOverviewSavedStateCard: View, Equatable {
                         value: "\(stats.baselineSamples)/\(PersonalBaseline.trustedMinimumSamples)",
                         state: stats.baselineSamples >= PersonalBaseline.trustedMinimumSamples ? .validated : .learning,
                         tint: .pink)
+    }
+}
+
+
+/// Manual bucketing override for the detail charts (design handoff "Range &
+/// interval"). .auto keeps the shipped behavior: raw daily points on short
+/// ranges, weekly buckets past 90 days.
+enum AtriaChartBucketOverride: String, CaseIterable, Identifiable {
+    case auto, daily, weeklyAverage
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .auto: return "Auto"
+        case .daily: return "Daily"
+        case .weeklyAverage: return "Week avg"
+        }
+    }
+}
+
+/// Bottom sheet controlling how detail-chart points are bucketed and whether
+/// the weekly min-max band shows. The range picker on the sheet itself is
+/// the window control -- this deliberately controls bucketing only.
+struct AtriaChartOptionsSheet: View {
+    @Binding var bucketOverride: AtriaChartBucketOverride
+    @Binding var showMinMaxBand: Bool
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("BUCKET EACH POINT BY")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(.tertiary)
+                        .kerning(0.8)
+                    Picker("Bucket", selection: $bucketOverride) {
+                        ForEach(AtriaChartBucketOverride.allCases) { option in
+                            Text(option.label).tag(option)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    Text("Auto shows daily points on short ranges and weekly averages past 3 months.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Toggle(isOn: $showMinMaxBand) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Show min\u{2013}max band")
+                            .font(.subheadline.weight(.semibold))
+                        Text("Shades each week's real range around its average.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer(minLength: 0)
+            }
+            .padding(18)
+            .navigationTitle("Range & interval")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .font(.body.weight(.semibold))
+                }
+            }
+        }
     }
 }

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -3877,9 +3877,10 @@ struct AtriaWeeklyReportSheet: View {
                             .font(.headline.weight(.bold))
                             .foregroundStyle(.secondary)
                         Text(heroText)
-                            .font(.system(size: 42, weight: .bold, design: .rounded).monospacedDigit())
-                            .lineLimit(2)
-                            .minimumScaleFactor(0.72)
+                            .font(.system(size: 26, weight: .bold, design: .rounded))
+                            .lineLimit(3)
+                            .minimumScaleFactor(0.8)
+                            .fixedSize(horizontal: false, vertical: true)
                         Text(weekRangeText)
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(.secondary)
@@ -3976,10 +3977,33 @@ struct AtriaWeeklyReportSheet: View {
             .accessibilityAddTraits(.isHeader)
     }
 
+    /// Narrative hero (dedup audit + design HIGHLIGHTS card, 2026-07-07):
+    /// the hero used to repeat the Recovery-average stat row verbatim. It is
+    /// now a one-line story built ONLY from real report fields — every
+    /// clause is gated on data, phrasing stays associative ("while"/"with"),
+    /// never causal. Numbers live in the stat rows below.
     private var heroText: String {
-        guard let recovery = report.recoveryAvg else { return "Recovery building" }
-        guard let delta = report.recoveryDeltaVsPriorWeek else { return "\(recovery)%" }
-        return delta >= 0 ? "\(recovery)% +\(delta)" : "\(recovery)% \(delta)"
+        guard let _ = report.recoveryAvg else { return "Still building this week's picture" }
+
+        var clauses: [String] = []
+        if let delta = report.recoveryDeltaVsPriorWeek {
+            if delta >= 3 { clauses.append("Recovery climbed") }
+            else if delta <= -3 { clauses.append("Recovery dipped") }
+            else { clauses.append("Recovery held steady") }
+        } else {
+            clauses.append("Recovery on the board")
+        }
+        if let strain = report.strainAvg, strain > 0 {
+            if strain >= 12 { clauses.append("under a heavy training load") }
+            else if strain >= 8 { clauses.append("with a solid training load") }
+            else { clauses.append("with a light training load") }
+        }
+        if let sleep = report.sleepAvgSeconds, sleep > 0 {
+            if sleep >= 7.5 * 3600 { clauses.append("while sleep stayed long") }
+            else if sleep >= 6.5 * 3600 { clauses.append("while sleep hovered near need") }
+            else { clauses.append("while sleep ran short") }
+        }
+        return clauses.joined(separator: " ")
     }
 
     private var recoveryAverageText: String {
@@ -4159,9 +4183,10 @@ struct AtriaMonthlyReportSheet: View {
                             .font(.headline.weight(.bold))
                             .foregroundStyle(.secondary)
                         Text(heroText)
-                            .font(.system(size: 42, weight: .bold, design: .rounded).monospacedDigit())
-                            .lineLimit(2)
-                            .minimumScaleFactor(0.72)
+                            .font(.system(size: 26, weight: .bold, design: .rounded))
+                            .lineLimit(3)
+                            .minimumScaleFactor(0.8)
+                            .fixedSize(horizontal: false, vertical: true)
                         Text(monthTitleText)
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(.secondary)
@@ -4234,10 +4259,26 @@ struct AtriaMonthlyReportSheet: View {
             .accessibilityAddTraits(.isHeader)
     }
 
+    /// Narrative hero — same honesty-gated treatment as the weekly report
+    /// (dedup audit 2026-07-07): clauses only from real fields, associative
+    /// phrasing, numbers owned by the stat rows.
     private var heroText: String {
-        guard let recovery = report.recoveryAvg else { return "Recovery building" }
-        guard let delta = report.recoveryDeltaVsPriorMonth else { return "\(recovery)%" }
-        return delta >= 0 ? "\(recovery)% +\(delta)" : "\(recovery)% \(delta)"
+        guard let _ = report.recoveryAvg else { return "Still building this month's picture" }
+
+        var clauses: [String] = []
+        if let delta = report.recoveryDeltaVsPriorMonth {
+            if delta >= 3 { clauses.append("Recovery climbed") }
+            else if delta <= -3 { clauses.append("Recovery dipped") }
+            else { clauses.append("Recovery held steady") }
+        } else {
+            clauses.append("Recovery on the board")
+        }
+        if let sleepDelta = report.sleepPerformanceDeltaVsPriorMonth {
+            if sleepDelta >= 3 { clauses.append("while sleep improved") }
+            else if sleepDelta <= -3 { clauses.append("while sleep slipped") }
+            else { clauses.append("with steady sleep") }
+        }
+        return clauses.joined(separator: " ")
     }
 
     private var monthTitleText: String {

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6929,6 +6929,7 @@ struct AtriaMetricDetailSheet: View {
                                       tint: Metrics.electricStrain) {
                 strainWorkoutSection
                 strainZoneHistogramCard
+                strainActivityMixCard
             } contributors: {
                 AtriaMetricContributorRows(rows: strainContributorRows, tint: Metrics.electricStrain)
             } chart: {
@@ -7524,6 +7525,70 @@ struct AtriaMetricDetailSheet: View {
             .atriaInsetCard(tint: Metrics.electricStrain)
             .accessibilityElement(children: .combine)
             .accessibilityLabel("Time in zones today. " + histogram.map { "Zone \($0.zone.rawValue), \(Int($0.minutes.rounded())) minutes" }.joined(separator: ". ") + ".")
+        }
+    }
+
+    /// Activity-type classes for the strain mix split. HR alone cannot
+    /// measure muscular load, so this is honestly framed as an
+    /// activity-type split, never a muscle-load claim.
+    private static let strengthLeaningTypes: Set<String> = ["Strength", "HIIT", "Yoga"]
+
+    private var todayStrainMix: (cardio: Double, strength: Double)? {
+        var cardio = 0.0
+        var strength = 0.0
+        for workout in todayConfirmedWorkouts {
+            guard let strain = workout.strain, strain > 0 else { continue }
+            let type = workout.activityType ?? ""
+            if Self.strengthLeaningTypes.contains(type) {
+                strength += strain
+            } else if !type.isEmpty {
+                cardio += strain
+            }
+        }
+        guard cardio > 0 || strength > 0 else { return nil }
+        return (cardio, strength)
+    }
+
+    /// Cardio vs strength-type strain mix (design backlog item 9, honesty
+    /// adapted from the mock's "cardio vs muscular" — split by the workout's
+    /// activity type, which the user chose or confirmed).
+    @ViewBuilder
+    private var strainActivityMixCard: some View {
+        if let mix = todayStrainMix, mix.cardio > 0, mix.strength > 0 {
+            let total = mix.cardio + mix.strength
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Today's strain mix")
+                    .font(.subheadline.weight(.semibold))
+
+                GeometryReader { proxy in
+                    HStack(spacing: 3) {
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Metrics.electricStrain.opacity(0.85))
+                            .frame(width: max(10, proxy.size.width * mix.cardio / total))
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(Color.purple.opacity(0.8))
+                    }
+                }
+                .frame(height: 14)
+
+                HStack(spacing: 14) {
+                    Label(String(format: "Cardio %.1f", mix.cardio), systemImage: "figure.walk")
+                        .foregroundStyle(Metrics.electricStrain)
+                    Label(String(format: "Strength-type %.1f", mix.strength), systemImage: "dumbbell.fill")
+                        .foregroundStyle(.purple)
+                    Spacer(minLength: 0)
+                }
+                .font(.caption.weight(.bold).monospacedDigit())
+
+                Text("Split by the activity type of today's workouts \u{2014} heart-rate strain grouped by what you logged, not a muscle-load measurement.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(14)
+            .atriaInsetCard(tint: Metrics.electricStrain)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(String(format: "Today's strain mix. Cardio %.1f, strength-type %.1f, split by activity type.", mix.cardio, mix.strength))
         }
     }
 

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6604,6 +6604,7 @@ struct AtriaMetricDetailSheet: View {
     private let rollups: [DailyRollupStoreEntry]
     @State private var openedHistoryDay: AtriaHistoryDay?
     @State private var showChartOptions = false
+    @State private var showExpandedChart = false
     @State private var bucketOverride: AtriaChartBucketOverride
     @State private var showMinMaxBand: Bool
     let vo2MaxEstimate: VO2MaxEstimateSummary?
@@ -6693,6 +6694,18 @@ struct AtriaMetricDetailSheet: View {
                                     recoveryEstimate: recoveryEstimate,
                                     sleepGoalHours: sleepGoalHours)
         }
+        .fullScreenCover(isPresented: $showExpandedChart) {
+            if let config = expandedChartConfig {
+                AtriaExpandedChartView(title: config.title,
+                                       unit: config.unit,
+                                       tint: config.tint,
+                                       points: config.points,
+                                       priorPoints: config.prior,
+                                       baselineBand: config.band,
+                                       events: expandedChartEvents,
+                                       onDismiss: { showExpandedChart = false })
+            }
+        }
         .sheet(isPresented: $showChartOptions) {
             AtriaChartOptionsSheet(bucketOverride: $bucketOverride,
                                    showMinMaxBand: $showMinMaxBand)
@@ -6736,7 +6749,8 @@ struct AtriaMetricDetailSheet: View {
                                 priorPoints: preparedHistory.recoveryPrior[range] ?? [],
                                 companions: [("That day's HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? []),
                                              ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])],
-                                onOpenDay: { day in openHistoryDay(for: day) })
+                                onOpenDay: { day in openHistoryDay(for: day) },
+                                onExpand: { showExpandedChart = true })
                 }
             } about: {
                 aboutDisclosure
@@ -6766,7 +6780,8 @@ struct AtriaMetricDetailSheet: View {
                                 priorPoints: preparedHistory.hrvPrior[range] ?? [],
                                 companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
                                              ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])],
-                                onOpenDay: { day in openHistoryDay(for: day) })
+                                onOpenDay: { day in openHistoryDay(for: day) },
+                                onExpand: { showExpandedChart = true })
                 }
             } about: {
                 aboutDisclosure
@@ -6796,7 +6811,8 @@ struct AtriaMetricDetailSheet: View {
                                 priorPoints: preparedHistory.restingHeartRatePrior[range] ?? [],
                                 companions: [("That day's HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? []),
                                              ("Recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? [])],
-                                onOpenDay: { day in openHistoryDay(for: day) })
+                                onOpenDay: { day in openHistoryDay(for: day) },
+                                onExpand: { showExpandedChart = true })
                 }
             } about: {
                 aboutDisclosure
@@ -6855,7 +6871,8 @@ struct AtriaMetricDetailSheet: View {
                                 priorPoints: preparedHistory.sleepPrior[range] ?? [],
                                 companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
                                              ("HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? [])],
-                                onOpenDay: { day in openHistoryDay(for: day) })
+                                onOpenDay: { day in openHistoryDay(for: day) },
+                                onExpand: { showExpandedChart = true })
                 }
             } about: {
                 aboutDisclosure
@@ -6886,7 +6903,8 @@ struct AtriaMetricDetailSheet: View {
                                 priorPoints: preparedHistory.strainPrior[range] ?? [],
                                 companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
                                              ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])],
-                                onOpenDay: { day in openHistoryDay(for: day) })
+                                onOpenDay: { day in openHistoryDay(for: day) },
+                                onExpand: { showExpandedChart = true })
                 }
             } about: {
                 aboutDisclosure
@@ -7493,7 +7511,8 @@ struct AtriaMetricDetailSheet: View {
                              emptyExplanation: String? = nil,
                              priorPoints: [AtriaDetailChartPoint] = [],
                              companions: [(title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint])] = [],
-                             onOpenDay: ((Date) -> Void)? = nil) -> some View {
+                             onOpenDay: ((Date) -> Void)? = nil,
+                             onExpand: (() -> Void)? = nil) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Text(title)
@@ -7503,6 +7522,16 @@ struct AtriaMetricDetailSheet: View {
                     Text(latestText(value: latest.value, unit: unit))
                         .font(.caption.monospacedDigit())
                         .foregroundStyle(tint)
+                }
+                if let onExpand, points.count >= 2 {
+                    Button(action: onExpand) {
+                        Image(systemName: "arrow.up.left.and.arrow.down.right")
+                            .font(.caption.weight(.bold))
+                            .foregroundStyle(.secondary)
+                            .frame(width: 32, height: 32)
+                            .contentShape(Rectangle())
+                    }
+                    .accessibilityLabel("Expand chart: landscape, zoom, range selection, activity markers")
                 }
             }
 
@@ -7744,6 +7773,60 @@ struct AtriaMetricDetailSheet: View {
             values.append(comparison.priorAverage)
         }
         return AtriaTrendChartScale.domain(values: values)
+    }
+
+    /// Real saved activity for the expanded chart's marker lane: confirmed
+    /// workouts (strain hue) and confirmed sleep nights (sleep hue). Only
+    /// records that exist — an empty day has no marker.
+    private var expandedChartEvents: [AtriaChartEvent] {
+        var events: [AtriaChartEvent] = confirmedWorkouts.map { workout in
+            AtriaChartEvent(id: "workout-\(workout.id)",
+                            day: workout.start,
+                            label: workout.activitySubtype ?? workout.activityType ?? "Workout",
+                            systemImage: "flame.fill",
+                            tint: Metrics.electricStrain)
+        }
+        events.append(contentsOf: sleepHistory.nights.filter(\.confirmed).map { night in
+            AtriaChartEvent(id: "sleep-\(night.id)",
+                            day: night.day,
+                            label: "Sleep",
+                            systemImage: "bed.double.fill",
+                            tint: Metrics.electricSleep)
+        })
+        return events
+    }
+
+    /// The expanded chart mirrors whatever the inline chart currently shows
+    /// for the six core metrics (same override, same ghost, same band).
+    private var expandedChartConfig: (title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint], prior: [AtriaDetailChartPoint], band: AtriaDetailBaselineBand?)? {
+        switch metric {
+        case .recovery:
+            return ("Recovery", "%", Metrics.electricGreen,
+                    displayedPoints(auto: preparedHistory.recovery[range] ?? [], raw: preparedHistory.recoveryRaw[range] ?? []),
+                    preparedHistory.recoveryPrior[range] ?? [], nil)
+        case .hrv:
+            return ("HRV", "ms", metric.tint,
+                    displayedPoints(auto: preparedHistory.hrv[range] ?? [], raw: preparedHistory.hrvRaw[range] ?? []),
+                    preparedHistory.hrvPrior[range] ?? [], hrvBand)
+        case .restingHeartRate:
+            return ("Resting HR", "bpm", metric.tint,
+                    displayedPoints(auto: preparedHistory.restingHeartRate[range] ?? [], raw: preparedHistory.restingHeartRateRaw[range] ?? []),
+                    preparedHistory.restingHeartRatePrior[range] ?? [], restingBand)
+        case .respiratoryRate:
+            return ("Respiratory rate", "/min", metric.tint,
+                    displayedPoints(auto: preparedHistory.respiratoryRate[range] ?? [], raw: preparedHistory.respiratoryRateRaw[range] ?? []),
+                    preparedHistory.respiratoryRatePrior[range] ?? [], respiratoryBand)
+        case .sleep:
+            return ("Sleep duration", "h", Metrics.electricSleep,
+                    displayedPoints(auto: preparedHistory.sleep[range] ?? [], raw: preparedHistory.sleepRaw[range] ?? []),
+                    preparedHistory.sleepPrior[range] ?? [], nil)
+        case .strain:
+            return ("Strain", "", Metrics.electricStrain,
+                    displayedPoints(auto: preparedHistory.strain[range] ?? [], raw: preparedHistory.strainRaw[range] ?? []),
+                    preparedHistory.strainPrior[range] ?? [], nil)
+        default:
+            return nil
+        }
     }
 
     private var chartSupportsOptions: Bool {
@@ -9810,7 +9893,7 @@ private struct AtriaPreparedMetricHistory {
     }
 }
 
-private struct AtriaDetailChartPoint: Identifiable {
+struct AtriaDetailChartPoint: Identifiable {
     let day: Date
     let value: Double
     let tint: Color
@@ -9822,7 +9905,7 @@ private struct AtriaDetailChartPoint: Identifiable {
     var id: Date { day }
 }
 
-private struct AtriaDetailBaselineBand {
+struct AtriaDetailBaselineBand {
     let lower: Double
     let upper: Double
     let tint: Color

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6896,6 +6896,7 @@ struct AtriaMetricDetailSheet: View {
                                                                                     yesterdayStrain: yesterdayStrainForLatestNight),
                                             consistencyPercent: sleepHistory.sleepConsistencyPercent)
                     sleepNeedLedgerCard(for: latest)
+                    sleepDebtTrendCard
                 }
             } contributors: {
                 AtriaMetricContributorRows(rows: sleepContributorRows, tint: Metrics.electricSleep)
@@ -7225,6 +7226,69 @@ struct AtriaMetricDetailSheet: View {
     /// "How much you needed" ledger (design handoff): itemizes the four real
     /// terms of the sleep-need math. The total is the exact number the
     /// hypnogram card's need uses -- never a separately computed figure.
+    /// One night's surplus/deficit vs the clamped base need, for the debt
+    /// trend card. Real confirmed nights only.
+    private var sleepDebtTrendPoints: [(day: Date, deltaHours: Double)] {
+        let clampedNeed = min(max(sleepBaseNeedHours, 6), 10)
+        return sleepHistory.nights
+            .filter { !$0.isNapEvidence }
+            .prefix(14)
+            .map { (day: $0.day, deltaHours: $0.durationHours - clampedNeed) }
+            .reversed()
+    }
+
+    /// Sleep-debt trend (design backlog item 4): nightly surplus/deficit
+    /// bars vs the base need, headlined by the SAME 7-night debt number the
+    /// need ledger uses — one math, two views of it.
+    @ViewBuilder
+    private var sleepDebtTrendCard: some View {
+        let points = sleepDebtTrendPoints
+        if points.count >= 3 {
+            let debt = sleepHistory.sleepBudgetDebtHours(baseNeedHours: sleepBaseNeedHours)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack {
+                    Text("Sleep debt")
+                        .font(.subheadline.weight(.semibold))
+                    Spacer()
+                    Text(debt > 0.05 ? "\(AtriaMetricFormat.sleepHours(debt)) owed" : "None owed")
+                        .font(.caption.weight(.bold).monospacedDigit())
+                        .foregroundStyle(debt > 0.05 ? .orange : Metrics.electricGreen)
+                }
+
+                Chart(points, id: \.day) { point in
+                    BarMark(x: .value("Night", point.day, unit: .day),
+                            y: .value("vs need", point.deltaHours))
+                        .foregroundStyle(point.deltaHours >= 0 ? Metrics.electricSleep.opacity(0.85) : Color.orange.opacity(0.85))
+                        .cornerRadius(3)
+                    RuleMark(y: .value("Need met", 0))
+                        .foregroundStyle(.secondary.opacity(0.4))
+                        .lineStyle(StrokeStyle(lineWidth: 1))
+                }
+                .chartYAxis {
+                    AxisMarks(position: .trailing, values: .automatic(desiredCount: 3)) { value in
+                        AxisGridLine()
+                        AxisValueLabel {
+                            if let hours = value.as(Double.self) {
+                                Text(String(format: "%+.0fh", hours))
+                            }
+                        }
+                    }
+                }
+                .frame(height: 96)
+                .clipped()
+
+                Text("Each bar: that night vs your base need (\(AtriaMetricFormat.sleepHours(min(max(sleepBaseNeedHours, 6), 10)))). Debt counts the last 7 nights.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(14)
+            .atriaInsetCard(tint: Metrics.electricSleep)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Sleep debt trend. \(debt > 0.05 ? AtriaMetricFormat.sleepHours(debt) + " owed" : "No debt owed"). Bars show each night versus base need.")
+        }
+    }
+
     private func sleepNeedLedgerCard(for night: SleepHistorySnapshot.Night) -> some View {
         let comps = sleepHistory.sleepNeedComponents(for: night,
                                                      baseNeedHours: sleepBaseNeedHours,

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6924,6 +6924,7 @@ struct AtriaMetricDetailSheet: View {
                                       heroState: strainHeroState,
                                       tint: Metrics.electricStrain) {
                 strainWorkoutSection
+                strainZoneHistogramCard
             } contributors: {
                 AtriaMetricContributorRows(rows: strainContributorRows, tint: Metrics.electricStrain)
             } chart: {
@@ -7467,6 +7468,59 @@ struct AtriaMetricDetailSheet: View {
     private var todayHighZoneMinutesText: String {
         let minutes = Int((todayHighZoneSeconds / 60).rounded())
         return minutes > 0 ? "\(minutes)m" : "--"
+    }
+
+    /// Today's time-in-zones across confirmed workouts, keyed by HRZone.
+    /// Only real recorded zone seconds — no zone data, no bar.
+    private var todayZoneHistogram: [(zone: HRZone, minutes: Double)] {
+        let totals = todayConfirmedWorkouts.reduce(into: [String: TimeInterval]()) { partial, workout in
+            for (key, seconds) in workout.zoneSeconds ?? [:] {
+                partial[key, default: 0] += seconds
+            }
+        }
+        let keyByZone: [HRZone: String] = [.rest: "rest", .warmup: "warmup", .fatBurn: "fatBurn",
+                                           .aerobic: "aerobic", .anaerobic: "anaerobic", .max: "max"]
+        return HRZone.allCases.compactMap { zone in
+            guard let seconds = keyByZone[zone].flatMap({ totals[$0] }), seconds >= 30 else { return nil }
+            return (zone: zone, minutes: seconds / 60)
+        }
+    }
+
+    /// Strain time-in-zones histogram (design backlog item 5): minutes per
+    /// percent-of-max zone across today's confirmed workouts.
+    @ViewBuilder
+    private var strainZoneHistogramCard: some View {
+        let histogram = todayZoneHistogram
+        if !histogram.isEmpty {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("Today in zones")
+                    .font(.subheadline.weight(.semibold))
+
+                Chart(histogram, id: \.zone) { entry in
+                    BarMark(x: .value("Zone", "Z\(entry.zone.rawValue)"),
+                            y: .value("Minutes", entry.minutes))
+                        .foregroundStyle(entry.zone.color.opacity(0.85))
+                        .cornerRadius(4)
+                        .annotation(position: .top, spacing: 2) {
+                            Text("\(Int(entry.minutes.rounded()))m")
+                                .font(.caption2.weight(.bold).monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                }
+                .chartYAxis(.hidden)
+                .frame(height: 110)
+                .clipped()
+
+                Text("Minutes per heart-rate zone across today's workouts. Zones use your percent-of-max bands.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(14)
+            .atriaInsetCard(tint: Metrics.electricStrain)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Time in zones today. " + histogram.map { "Zone \($0.zone.rawValue), \(Int($0.minutes.rounded())) minutes" }.joined(separator: ". ") + ".")
+        }
     }
 
     private var strainWorkoutSection: some View {

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6623,8 +6623,10 @@ struct AtriaMetricDetailSheet: View {
          maxHeartRate: Int? = nil,
          vo2MaxEstimate: VO2MaxEstimateSummary? = nil,
          skinTemperatureDeviation: IMUAuditSummary.SkinTemperatureDeviationSummary? = nil,
-         initialRange: AtriaTrendRange = .month) {
+         initialRange: AtriaTrendRange = .month,
+         initialScrubbedDay: Date? = nil) {
         _range = State(initialValue: initialRange)
+        _scrubbedDay = State(initialValue: initialScrubbedDay)
         self.metric = metric
         self.confirmedWorkouts = confirmedWorkouts
         self.baseline = baseline
@@ -6693,7 +6695,9 @@ struct AtriaMetricDetailSheet: View {
                                 comparison: preparedHistory.recoveryComparison[range],
                                 baselineBand: nil,
                                 accessibilitySummary: "Recovery over \(range.label).",
-                                priorPoints: preparedHistory.recoveryPrior[range] ?? [])
+                                priorPoints: preparedHistory.recoveryPrior[range] ?? [],
+                                companions: [("That day's HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? []),
+                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])])
                 }
             } about: {
                 aboutDisclosure
@@ -6720,7 +6724,9 @@ struct AtriaMetricDetailSheet: View {
                                 baselineBand: hrvBand,
                                 accessibilitySummary: "HRV over \(range.label) with your baseline band.",
                                 emptyExplanation: "HRV is read from steady overnight wear — each clean night adds a point here.",
-                                priorPoints: preparedHistory.hrvPrior[range] ?? [])
+                                priorPoints: preparedHistory.hrvPrior[range] ?? [],
+                                companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
+                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])])
                 }
             } about: {
                 aboutDisclosure
@@ -6747,7 +6753,9 @@ struct AtriaMetricDetailSheet: View {
                                 baselineBand: restingBand,
                                 accessibilitySummary: "Resting heart rate over \(range.label) with your baseline band.",
                                 emptyExplanation: "Resting heart rate is read from overnight wear — each night adds a point here.",
-                                priorPoints: preparedHistory.restingHeartRatePrior[range] ?? [])
+                                priorPoints: preparedHistory.restingHeartRatePrior[range] ?? [],
+                                companions: [("That day's HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? []),
+                                             ("Recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? [])])
                 }
             } about: {
                 aboutDisclosure
@@ -6803,7 +6811,9 @@ struct AtriaMetricDetailSheet: View {
                                 comparison: preparedHistory.sleepComparison[range],
                                 baselineBand: nil,
                                 accessibilitySummary: "Sleep duration over \(range.label).",
-                                priorPoints: preparedHistory.sleepPrior[range] ?? [])
+                                priorPoints: preparedHistory.sleepPrior[range] ?? [],
+                                companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
+                                             ("HRV", "ms", Metrics.electricHRV, preparedHistory.hrv[range] ?? [])])
                 }
             } about: {
                 aboutDisclosure
@@ -6831,7 +6841,9 @@ struct AtriaMetricDetailSheet: View {
                                 comparison: preparedHistory.strainComparison[range],
                                 baselineBand: nil,
                                 accessibilitySummary: "Strain over \(range.label).",
-                                priorPoints: preparedHistory.strainPrior[range] ?? [])
+                                priorPoints: preparedHistory.strainPrior[range] ?? [],
+                                companions: [("That day's recovery", "%", Metrics.electricGreen, preparedHistory.recovery[range] ?? []),
+                                             ("Sleep", "h", Metrics.electricSleep, preparedHistory.sleep[range] ?? [])])
                 }
             } about: {
                 aboutDisclosure
@@ -7436,7 +7448,8 @@ struct AtriaMetricDetailSheet: View {
                              baselineBand: AtriaDetailBaselineBand?,
                              accessibilitySummary: String,
                              emptyExplanation: String? = nil,
-                             priorPoints: [AtriaDetailChartPoint] = []) -> some View {
+                             priorPoints: [AtriaDetailChartPoint] = [],
+                             companions: [(title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint])] = []) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
                 Text(title)
@@ -7577,6 +7590,15 @@ struct AtriaMetricDetailSheet: View {
                                     Text(selectedPoint.day, format: .dateTime.month(.abbreviated).day())
                                         .font(.caption2)
                                         .foregroundStyle(.secondary)
+                                    // vs-typical delta, only when a REAL
+                                    // trusted baseline band exists (design
+                                    // handoff scrub callout).
+                                    if let baselineBand {
+                                        let delta = selectedPoint.value - (baselineBand.lower + baselineBand.upper) / 2
+                                        Text(String(format: "%+.0f vs typical", delta))
+                                            .font(.caption2.weight(.semibold))
+                                            .foregroundStyle(.secondary)
+                                    }
                                 }
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 4)
@@ -7618,6 +7640,30 @@ struct AtriaMetricDetailSheet: View {
                     Text("Dashed line: the previous period, overlaid")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
+                }
+
+                // Scrub-linked companion tiles (design handoff): while a day
+                // is selected, sibling metrics for THAT day appear beneath the
+                // chart. A companion with no real value that day shows nothing
+                // for it (fail closed, never interpolated).
+                if let target = scrubbedDay, !companions.isEmpty {
+                    HStack(spacing: 8) {
+                        ForEach(Array(companions.enumerated()), id: \.offset) { _, companion in
+                            let match = companion.points.first { Calendar.current.isDate($0.day, inSameDayAs: target) }
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(companion.title.uppercased())
+                                    .font(.caption2.weight(.black))
+                                    .foregroundStyle(.tertiary)
+                                Text(match.map { latestText(value: $0.value, unit: companion.unit) } ?? "\u{2014}")
+                                    .font(.subheadline.weight(.bold).monospacedDigit())
+                                    .foregroundStyle(match == nil ? .secondary : companion.tint)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(10)
+                            .background(companion.tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        }
+                    }
+                    .transition(.opacity)
                 }
             }
         }

--- a/Atria/Atria/AtriaStrapScreen.swift
+++ b/Atria/Atria/AtriaStrapScreen.swift
@@ -37,11 +37,9 @@ struct AtriaStrapScreen: View {
             connectionHero
 
             VStack(spacing: 8) {
-                AtriaStrapStatusRow(title: "Connection",
-                                    value: connectionValue,
-                                    detail: connectionDetail,
-                                    systemImage: connectionSymbol,
-                                    tint: connectionTint)
+                // Connection row removed (dedup audit 2026-07-07): the
+                // state-differentiated hero above renders the identical
+                // value + detail strings; the row added nothing.
                 AtriaStrapStatusRow(title: "Battery",
                                     value: coreLiveStore.state.batteryText,
                                     detail: coreLiveStore.state.batteryChargeCompactText,
@@ -168,11 +166,9 @@ struct AtriaStrapScreen: View {
         switch displayStatus {
         case .connected:
             HStack(spacing: 12) {
-                Image(systemName: "sensor.tag.radiowaves.forward.fill")
-                    .font(.title3.weight(.bold))
-                    .foregroundStyle(Metrics.electricGreen)
-                    .frame(width: 44, height: 44)
-                    .background(Metrics.electricGreen.opacity(0.14), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                // The state-driven symbol the removed Connection row used —
+                // the hero now owns it (dedup audit 2026-07-07).
+                heroStatusIcon(systemImage: connectionSymbol, tint: Metrics.electricGreen)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(primaryState)
                         .font(.headline.weight(.bold))
@@ -183,15 +179,8 @@ struct AtriaStrapScreen: View {
                         .lineLimit(2)
                 }
                 Spacer(minLength: 8)
-                if coreLiveStore.state.batteryLevel >= 0 {
-                    VStack(alignment: .trailing, spacing: 1) {
-                        Text(coreLiveStore.state.batteryText)
-                            .font(.headline.weight(.bold).monospacedDigit())
-                        Text("Battery")
-                            .font(.caption2.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                    }
-                }
+                // Battery block removed from the hero (dedup audit): the
+                // Battery status row below owns the value + charging detail.
             }
             .padding(14)
             .atriaInsetCard(tint: Metrics.electricGreen)
@@ -252,6 +241,14 @@ struct AtriaStrapScreen: View {
         }
     }
 
+    private func heroStatusIcon(systemImage: String, tint: Color) -> some View {
+        Image(systemName: systemImage)
+            .font(.title3.weight(.bold))
+            .foregroundStyle(tint)
+            .frame(width: 44, height: 44)
+            .background(tint.opacity(0.14), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
@@ -267,14 +264,8 @@ struct AtriaStrapScreen: View {
 
                 Spacer(minLength: 8)
 
-                Text(primaryState)
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(connectionTint)
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 6)
-                    .background(connectionTint.opacity(0.12), in: Capsule(style: .continuous))
-                    .fixedSize()
-                    .layoutPriority(1)
+                // Header state capsule removed (dedup audit): primaryState
+                // renders as the hero headline one card below.
             }
 
             Text("Your strap, your data — Atria reads it over Bluetooth. Nothing is sent to WHOOP.")

--- a/Atria/Atria/AtriaStrapScreen.swift
+++ b/Atria/Atria/AtriaStrapScreen.swift
@@ -22,6 +22,9 @@ struct AtriaStrapScreen: View {
     @Binding var hapticSettings: AtriaHapticAlertSettings
     let officialAppInstalled: Bool
     let developerModeEnabled: Bool
+    /// Opens the status-aware connection guide sheet (owned by AtriaHomeView).
+    /// Optional so previews/tests without the home context still compile.
+    var onShowConnectionGuide: (() -> Void)? = nil
     @State private var rawExportURL: URL?
     @State private var rawExportInProgress = false
     @State private var rawExportStatus = "Full-resolution zip"
@@ -30,6 +33,8 @@ struct AtriaStrapScreen: View {
         let _ = AtriaBodyEvalProbe.tick("AtriaStrapScreen")
         VStack(alignment: .leading, spacing: 14) {
             header
+
+            connectionHero
 
             VStack(spacing: 8) {
                 AtriaStrapStatusRow(title: "Connection",
@@ -153,6 +158,99 @@ struct AtriaStrapScreen: View {
             && arguments[valueIndex] == "raw-export-ready"
     }
     #endif
+
+    /// State-differentiated connection hero (design handoff, user-approved
+    /// over the auto-scan-only deferral 2026-07-07). The scan button triggers
+    /// the same scan the chrome chip tap runs — auto-scan keeps working;
+    /// this only adds a visible affordance.
+    @ViewBuilder
+    private var connectionHero: some View {
+        switch displayStatus {
+        case .connected:
+            HStack(spacing: 12) {
+                Image(systemName: "sensor.tag.radiowaves.forward.fill")
+                    .font(.title3.weight(.bold))
+                    .foregroundStyle(Metrics.electricGreen)
+                    .frame(width: 44, height: 44)
+                    .background(Metrics.electricGreen.opacity(0.14), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(primaryState)
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(Metrics.electricGreen)
+                    Text(connectionDetail)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 8)
+                if coreLiveStore.state.batteryLevel >= 0 {
+                    VStack(alignment: .trailing, spacing: 1) {
+                        Text(coreLiveStore.state.batteryText)
+                            .font(.headline.weight(.bold).monospacedDigit())
+                        Text("Battery")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .padding(14)
+            .atriaInsetCard(tint: Metrics.electricGreen)
+        case .connecting, .scanning:
+            HStack(spacing: 12) {
+                ProgressView()
+                    .controlSize(.regular)
+                    .frame(width: 44, height: 44)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Connecting\u{2026}")
+                        .font(.headline.weight(.bold))
+                        .foregroundStyle(.blue)
+                    Text(connectionDetail)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(14)
+            .atriaInsetCard(tint: .blue)
+        case .disconnected, .poweredOff:
+            VStack(spacing: 10) {
+                Image(systemName: "sensor.tag.radiowaves.forward")
+                    .font(.title2.weight(.bold))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 48, height: 48)
+                    .background(.quaternary.opacity(0.3), in: RoundedRectangle(cornerRadius: 13, style: .continuous))
+                Text("Not connected")
+                    .font(.headline.weight(.bold))
+                Text(displayStatus == .poweredOff
+                     ? "Turn on Bluetooth to begin \u{2014} Atria reconnects automatically."
+                     : "Bring your strap into range to begin \u{2014} Atria scans automatically.")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                Button {
+                    ble.startScan(reason: "strap_screen_hero")
+                } label: {
+                    Label("Scan for strap", systemImage: "dot.radiowaves.left.and.right")
+                        .font(.subheadline.weight(.bold))
+                        .frame(maxWidth: .infinity, minHeight: 34)
+                }
+                .buttonStyle(.glassProminent)
+                if let onShowConnectionGuide {
+                    Button("Connection guide") {
+                        onShowConnectionGuide()
+                    }
+                    .font(.caption.weight(.bold))
+                    .frame(minHeight: 40)
+                    .contentShape(Rectangle())
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(16)
+            .atriaInsetCard(tint: .secondary)
+        }
+    }
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 8) {

--- a/Atria/Atria/AtriaTodayScreen.swift
+++ b/Atria/Atria/AtriaTodayScreen.swift
@@ -131,6 +131,7 @@ struct AtriaTodayScreen: View {
             AtriaMetricDetailSheet(metric: detail,
                                    rollups: highlightRollups,
                                    confirmedWorkouts: debugMetricDetailWorkouts ?? store.confirmedWorkouts,
+                                   behaviorImpacts: store.behaviorImpactSummariesCache,
                                    baseline: AtriaBaselineTargetSnapshot(store.baseline),
                                    sleepHistory: store.sleepHistorySnapshot,
                                    guidance: displayHero.guidance,

--- a/Atria/Atria/AtriaTodayScreen.swift
+++ b/Atria/Atria/AtriaTodayScreen.swift
@@ -451,12 +451,28 @@ struct AtriaTodayScreen: View {
     /// the hero, the share-as-picture render, and the accessibility
     /// summary so all three always agree.
     private func metric(for slot: AtriaTriRingSlot) -> AtriaTriRingMetric {
+        var metric: AtriaTriRingMetric
         switch slot {
-        case .sleep: return sleepMetric
-        case .recovery: return recoveryMetric
-        case .strain: return strainMetric
-        case .hrv: return hrvMetric
-        case .rhr: return restingHeartRateMetric
+        case .sleep: metric = sleepMetric
+        case .recovery: metric = recoveryMetric
+        case .strain: metric = strainMetric
+        case .hrv: metric = hrvMetric
+        case .rhr: metric = restingHeartRateMetric
+        }
+        // The ring center already shows this slot's numeral — the chip
+        // keeps title + detail only (dedup audit 2026-07-07).
+        if slotMatchesRingCenter(slot) {
+            metric.suppressesValue = true
+        }
+        return metric
+    }
+
+    private func slotMatchesRingCenter(_ slot: AtriaTriRingSlot) -> Bool {
+        switch (slot, layoutConfig.ringCenterMetric) {
+        case (.sleep, .sleep), (.recovery, .recovery), (.strain, .strain):
+            return true
+        default:
+            return false
         }
     }
 

--- a/Atria/Atria/AtriaTrendChart.swift
+++ b/Atria/Atria/AtriaTrendChart.swift
@@ -9,6 +9,9 @@ import Charts
 struct AtriaTrendChartCard: View {
     let points: [AtriaTrendPoint]
     let baselineRestingHR: Int?
+    /// Real saved activity for the expanded chart's marker lane. Optional so
+    /// existing call sites/tests compile unchanged.
+    var events: [AtriaChartEvent] = []
 
     @State private var metric: AtriaTrendMetric = .restingHR
     @State private var range: AtriaTrendRange = .month
@@ -150,15 +153,35 @@ struct AtriaTrendChartCard: View {
         .onChange(of: baselineRestingHR) { _, _ in refreshPreparedSeries() }
         .onChange(of: metric) { _, _ in refreshPreparedSeries() }
         .onChange(of: range) { _, _ in refreshPreparedSeries() }
-        .sheet(isPresented: $showExpandedChart) {
-            AtriaTrendExpandedSheet(title: "\(metric.shortLabel) trend",
-                                    subtitle: range.headerLabel,
-                                    chart: AnyView(chart),
-                                    explainer: metric.trendExplainer,
-                                    tint: metric.tint)
-                .presentationDetents([.large])
-                .presentationDragIndicator(.visible)
+        // Landscape expanded chart (user feedback 2026-07-07): replaces the
+        // old portrait sheet with the shared zoom/brush/markers experience.
+        .fullScreenCover(isPresented: $showExpandedChart) {
+            AtriaExpandedChartView(title: "\(metric.shortLabel) trend",
+                                   unit: expandedUnit,
+                                   tint: metric.tint,
+                                   points: expandedChartPoints,
+                                   events: events,
+                                   onDismiss: { showExpandedChart = false })
         }
+    }
+
+    private var expandedUnit: String {
+        switch metric {
+        case .restingHR: return " bpm"
+        case .strain: return ""
+        case .hrv: return " ms"
+        }
+    }
+
+    /// The focused metric's real daily values in the shared chart-point
+    /// shape. Days without a value are simply absent.
+    private var expandedChartPoints: [AtriaDetailChartPoint] {
+        points.compactMap { point in
+            point.value(for: metric).map {
+                AtriaDetailChartPoint(day: point.date, value: $0, tint: metric.tint)
+            }
+        }
+        .sorted { $0.day < $1.day }
     }
 
     private func refreshPreparedSeries(now: Date = Date()) {
@@ -2298,7 +2321,27 @@ struct AtriaOverviewTrendChartHost: View {
     var body: some View {
         let fixturePoints = debugFixtureTrendPoints
         AtriaTrendChartCard(points: fixturePoints ?? store.overviewTrendPoints,
-                            baselineRestingHR: fixturePoints == nil ? store.baseline.restingInt : 58)
+                            baselineRestingHR: fixturePoints == nil ? store.baseline.restingInt : 58,
+                            events: trendEvents)
+    }
+
+    /// Real saved activity for the expanded chart marker lane.
+    private var trendEvents: [AtriaChartEvent] {
+        var events: [AtriaChartEvent] = store.confirmedWorkouts.map { workout in
+            AtriaChartEvent(id: "workout-\(workout.id)",
+                            day: workout.start,
+                            label: workout.activitySubtype ?? workout.activityType ?? "Workout",
+                            systemImage: "flame.fill",
+                            tint: Metrics.electricStrain)
+        }
+        events.append(contentsOf: store.sleepHistorySnapshot.nights.filter(\.confirmed).map { night in
+            AtriaChartEvent(id: "sleep-\(night.id)",
+                            day: night.day,
+                            label: "Sleep",
+                            systemImage: "bed.double.fill",
+                            tint: Metrics.electricSleep)
+        })
+        return events
     }
 
     #if DEBUG

--- a/Atria/Atria/AtriaTrendChart.swift
+++ b/Atria/Atria/AtriaTrendChart.swift
@@ -107,10 +107,10 @@ struct AtriaTrendChartCard: View {
             }
 
             if showMoreInsights {
-                AtriaTrendRangeDock(selectedRange: $range,
-                                    coverage: rangeCoverage,
-                                    tint: metric.tint)
-                    .equatable()
+                // AtriaTrendRangeDock unmounted (dedup audit 2026-07-07):
+                // it was a second control mutating the same $range as the
+                // segmented picker, with the day counts shown a third way.
+                // The struct stays for potential reuse of its coverage rail.
 
                 if periodReadout.hasEnoughSignal {
                     AtriaTrendRangeReportCard(readout: periodReadout)
@@ -574,26 +574,9 @@ private struct AtriaTrendGlanceBoard: View, Equatable {
                     .background(readout.tint.opacity(0.13), in: Capsule(style: .continuous))
             }
 
-            ZStack(alignment: .center) {
-                RoundedRectangle(cornerRadius: 20, style: .continuous)
-                    .fill(
-                        LinearGradient(colors: [
-                            .cyan.opacity(0.14),
-                            Metrics.electricStrain.opacity(0.10)
-                        ], startPoint: .topLeading, endPoint: .bottomTrailing)
-                    )
-
-                HStack(spacing: 0) {
-                    glanceLane(title: "Recovery", value: readout.recoveryReserve, tint: .cyan)
-                    Divider()
-                        .overlay(.secondary.opacity(0.16))
-                    glanceLane(title: "Strain", value: readout.loadPressure, tint: Metrics.electricStrain)
-                }
-                .padding(.horizontal, 10)
-                .padding(.vertical, 9)
-            }
-            .frame(height: 70)
-
+            // Reserve/Strain lanes removed (dedup audit 2026-07-07): the
+            // balance map is the single owner of that pair; this board keeps
+            // its unique per-metric delta gauges.
             HStack(spacing: 8) {
                 metricGauge(label: "HRV", delta: readout.hrv, tint: .cyan)
                 metricGauge(label: "RHR", delta: readout.restingHR, tint: .pink)

--- a/Atria/Atria/AtriaTrendChart.swift
+++ b/Atria/Atria/AtriaTrendChart.swift
@@ -905,10 +905,8 @@ private struct AtriaTrendPeriodBalanceMap: View, Equatable {
             }
             .frame(height: 116)
 
-            HStack(spacing: 8) {
-                balancePill("Reserve", value: readout.recoveryReserve, tint: .cyan)
-                balancePill("Load", value: readout.loadPressure, tint: Metrics.electricStrain)
-            }
+            // Reserve/Load pills removed (dedup audit 2026-07-07): the map
+            // dot IS the pair; the numbers live in its accessibility label.
         }
         .padding(12)
         .atriaInsetCard(cornerRadius: 20, tint: readout.tint)
@@ -1004,15 +1002,13 @@ private struct AtriaTrendRangeReportCard: View, Equatable {
                 reportTile(nextStep)
             }
 
-            HStack(spacing: 8) {
-                reportBar(label: "Res", value: readout.recoveryReserve, tint: .cyan)
-                reportBar(label: "Load", value: readout.loadPressure, tint: Metrics.electricStrain)
-            }
+            // Reserve/Load bars removed (dedup audit 2026-07-07): the
+            // balance map below is the single owner of that pair.
         }
         .padding(12)
         .atriaInsetCard(cornerRadius: 20, tint: readout.tint)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Trend range report. Best signal \(strongestSignal.value). Pressure \(pressureSignal.value). Next \(nextStep.value). Reserve \(Int((readout.recoveryReserve * 100).rounded())) percent. Load \(Int((readout.loadPressure * 100).rounded())) percent.")
+        .accessibilityLabel("Trend range report. Best signal \(strongestSignal.value). Pressure \(pressureSignal.value). Next \(nextStep.value).")
     }
 
     private func reportTile(_ item: (title: String, value: String, tint: Color, symbol: String)) -> some View {
@@ -1743,21 +1739,9 @@ private struct AtriaTrendRangeLens: View, Equatable {
             }
 
             Spacer(minLength: 6)
-
-            VStack(alignment: .trailing, spacing: 3) {
-                Text(summary?.latestText ?? "--")
-                    .font(.title3.weight(.black).monospacedDigit())
-                    .foregroundStyle(metric.tint)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.66)
-                    .contentTransition(.numericText())
-                    .animation(.snappy(duration: 0.3), value: summary?.latestText ?? "--")
-                Text(metric.shortLabel)
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(.secondary)
-                    .textCase(.uppercase)
-                    .tracking(0.5)
-            }
+            // Latest-number block removed (dedup audit 2026-07-07): the
+            // chart's end annotation and the position band own "latest";
+            // this lens keeps its coverage role only.
         }
         .padding(12)
         .background(metric.tint.opacity(0.06), in: RoundedRectangle(cornerRadius: 18, style: .continuous))
@@ -2097,13 +2081,11 @@ private struct AtriaTrendRangeSummaryStrip: View {
 
     var body: some View {
         LazyVGrid(columns: [GridItem(.flexible(), spacing: 8),
-                            GridItem(.flexible(), spacing: 8),
-                            GridItem(.flexible(), spacing: 8),
                             GridItem(.flexible(), spacing: 8)],
                   spacing: 8) {
-            summaryPill(label: "Latest", value: summary.latestText)
+            // Latest + Range pills removed (dedup audit 2026-07-07): the
+            // position band below states both with position context.
             summaryPill(label: "Avg", value: summary.averageText)
-            summaryPill(label: "Range", value: summary.rangeText)
             if let priorAverageText = summary.priorAverageText {
                 summaryPill(label: "Prior", value: priorAverageText)
             } else {
@@ -2111,7 +2093,7 @@ private struct AtriaTrendRangeSummaryStrip: View {
             }
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Trend summary. Latest \(summary.latestText), average \(summary.averageText), range \(summary.rangeText), \(summary.comparisonAccessibilityText).")
+        .accessibilityLabel("Trend summary. Average \(summary.averageText), \(summary.comparisonAccessibilityText).")
     }
 
     private func summaryPill(label: String, value: String) -> some View {

--- a/Atria/Atria/AtriaTriRing.swift
+++ b/Atria/Atria/AtriaTriRing.swift
@@ -26,6 +26,10 @@ struct AtriaTriRingMetric: Equatable {
     /// 1.0. Nil -- and no marker drawn -- whenever there isn't a real target
     /// to honestly show (never fabricated).
     var targetFraction: Double? = nil
+    /// True when the ring center already shows this metric's value — the
+    /// chip then renders title + detail only (dedup audit 2026-07-07: the
+    /// big center numeral repeated verbatim in its own legend chip).
+    var suppressesValue: Bool = false
 }
 
 /// Which ring band (outer/middle/inner) a slot draws on, AND -- since the
@@ -412,6 +416,9 @@ struct AtriaTriRing: View, Equatable {
                         .font(.caption2.weight(.bold))
                         .foregroundStyle(.secondary)
                         .lineLimit(1)
+                    // Value line suppressed when the ring center owns this
+                    // metric's numeral (dedup audit 2026-07-07).
+                    if !metric.suppressesValue {
                     HStack(spacing: 4) {
                         // Tiny zone-tint dot -- an at-a-glance under/optimal/
                         // over cue that doesn't depend on reading the number.
@@ -429,6 +436,7 @@ struct AtriaTriRing: View, Equatable {
                             .contentTransition(reduceMotion ? .identity : .numericText())
                             .lineLimit(1)
                             .minimumScaleFactor(0.80)
+                    }
                     }
                     // The name line above already says it -- don't repeat
                     // it when a learning-state detail defaults to the name.

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -2886,25 +2886,93 @@ struct AtriaHeartRateExplorer: View {
     }
 }
 
+/// One smoothed time bucket of the raw ~1 Hz heart-rate stream: the real
+/// min/max ceiling-and-floor plus the average — the user's requested
+/// treatment for dense HR windows ("such a dense graph is just a scribble").
+struct AtriaHeartRateBucket: Equatable, Identifiable {
+    let id: Date
+    let t: Date
+    let average: Double
+    let minBPM: Int
+    let maxBPM: Int
+}
+
 struct AtriaHeartRateAxisChart: View, Equatable {
     let points: [AtriaHomeModel.HeartRateChartPoint]
     let yDomain: ClosedRange<Int>
     @Binding var selectedTime: Date?
+    /// Precomputed at init (never in body): non-nil when the window is dense
+    /// enough that the raw line reads as noise.
+    private let buckets: [AtriaHeartRateBucket]?
+
+    init(points: [AtriaHomeModel.HeartRateChartPoint],
+         yDomain: ClosedRange<Int>,
+         selectedTime: Binding<Date?>) {
+        self.points = points
+        self.yDomain = yDomain
+        self._selectedTime = selectedTime
+        self.buckets = Self.smoothedBuckets(points: points)
+    }
+
+    /// ~72 buckets across the window once the raw stream exceeds 150 samples;
+    /// below that the raw line is already legible. Each bucket keeps the REAL
+    /// min/max and average of its samples — nothing synthesized.
+    static func smoothedBuckets(points: [AtriaHomeModel.HeartRateChartPoint],
+                                targetBuckets: Int = 72) -> [AtriaHeartRateBucket]? {
+        guard points.count > 150,
+              let first = points.first?.t,
+              let last = points.last?.t,
+              last > first else { return nil }
+        let span = last.timeIntervalSince(first)
+        let width = span / Double(targetBuckets)
+        var grouped: [Int: [Int]] = [:]
+        for point in points {
+            let index = min(targetBuckets - 1, Int(point.t.timeIntervalSince(first) / width))
+            grouped[index, default: []].append(point.bpm)
+        }
+        return grouped.keys.sorted().compactMap { index in
+            guard let bpms = grouped[index], !bpms.isEmpty else { return nil }
+            let center = first.addingTimeInterval((Double(index) + 0.5) * width)
+            return AtriaHeartRateBucket(id: center,
+                                        t: center,
+                                        average: Double(bpms.reduce(0, +)) / Double(bpms.count),
+                                        minBPM: bpms.min() ?? 0,
+                                        maxBPM: bpms.max() ?? 0)
+        }
+    }
 
     static func == (lhs: AtriaHeartRateAxisChart, rhs: AtriaHeartRateAxisChart) -> Bool {
         lhs.points == rhs.points && lhs.yDomain == rhs.yDomain
     }
 
     var body: some View {
-        Chart(points) { point in
-            AreaMark(x: .value("Time", point.t),
-                     yStart: .value("Visible floor", yDomain.lowerBound),
-                     yEnd: .value("BPM", point.bpm))
-                .interpolationMethod(.catmullRom)
-                .foregroundStyle(.red.opacity(0.12).gradient)
-            LineMark(x: .value("Time", point.t), y: .value("BPM", point.bpm))
-                .interpolationMethod(.catmullRom)
-                .foregroundStyle(.red.gradient)
+        Chart {
+            if let buckets {
+                // Smoothed mode: real min-max ceiling/floor band + average.
+                ForEach(buckets) { bucket in
+                    AreaMark(x: .value("Time", bucket.t),
+                             yStart: .value("Min", bucket.minBPM),
+                             yEnd: .value("Max", bucket.maxBPM))
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(.red.opacity(0.16))
+                    LineMark(x: .value("Time", bucket.t),
+                             y: .value("BPM", bucket.average))
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(.red.gradient)
+                        .lineStyle(StrokeStyle(lineWidth: 2))
+                }
+            } else {
+                ForEach(points) { point in
+                    AreaMark(x: .value("Time", point.t),
+                             yStart: .value("Visible floor", yDomain.lowerBound),
+                             yEnd: .value("BPM", point.bpm))
+                        .interpolationMethod(.catmullRom)
+                        .foregroundStyle(.red.opacity(0.12).gradient)
+                    LineMark(x: .value("Time", point.t), y: .value("BPM", point.bpm))
+                        .interpolationMethod(.catmullRom)
+                        .foregroundStyle(.red.gradient)
+                }
+            }
             if let selectedTime {
                 RuleMark(x: .value("Selected", selectedTime))
                     .foregroundStyle(.secondary.opacity(0.55))

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -81,6 +81,7 @@ struct AtriaVitalsTabContent: View {
             AtriaMetricDetailSheet(metric: detail,
                                    rollups: store.dailyRollupHistory,
                                    confirmedWorkouts: store.confirmedWorkouts,
+                                   behaviorImpacts: store.behaviorImpactSummariesCache,
                                    baseline: AtriaBaselineTargetSnapshot(store.baseline),
                                    sleepHistory: store.sleepHistorySnapshot,
                                    guidance: healthMonitorGuidance,

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -2988,7 +2988,9 @@ struct AtriaHeartRateAxisChart: View, Equatable {
             }
         }
         .chartYAxis {
-            AxisMarks(position: .leading, values: .automatic(desiredCount: 5)) { value in
+            // Trailing axis: the leading bpm gutter (~28pt) was the largest
+            // single left inset on the Vitals tab (space audit 2026-07-07).
+            AxisMarks(position: .trailing, values: .automatic(desiredCount: 5)) { value in
                 AxisGridLine()
                 AxisTick()
                 AxisValueLabel {

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -7701,7 +7701,9 @@ final class SessionStore: ObservableObject {
                       summary.strengthCandidate ? 1 : 0,
                       summary.moderateStrengthReviewCandidate ? 1 : 0)
         DetectionEventLog.append(DetectionEvent(kind: "workoutDetected",
-                                                 detail: "peak_over_rest=\(summary.bestPeakHR - rest), observed \(Int(summary.bestObservedDuration))s, coverage \(summary.bestStreamCoveragePercent)%"))
+                                                 detail: "peak_over_rest=\(summary.bestPeakHR - rest), observed \(Int(summary.bestObservedDuration))s, coverage \(summary.bestStreamCoveragePercent)%",
+                                                 windowStart: start,
+                                                 windowEnd: end))
         return WorkoutReviewCandidate(id: id,
                                       start: start,
                                       end: end,
@@ -7881,7 +7883,9 @@ final class SessionStore: ObservableObject {
               confirmed.zoneSeconds?["max"] ?? 0)
         DetectionEventLog.append(DetectionEvent(kind: "workoutDetected",
                                                  reason: "confirmed",
-                                                 detail: "\(confirmed.label), \(Int(confirmed.duration))s"))
+                                                 detail: "\(confirmed.label), \(Int(confirmed.duration))s",
+                                                 windowStart: confirmed.start,
+                                                 windowEnd: confirmed.end))
         return confirmed
     }
 
@@ -8049,7 +8053,9 @@ final class SessionStore: ObservableObject {
               confirmed.zoneSeconds?["max"] ?? 0)
         DetectionEventLog.append(DetectionEvent(kind: "workoutDetected",
                                                  reason: "confirmed",
-                                                 detail: "\(confirmed.label), \(Int(confirmed.duration))s"))
+                                                 detail: "\(confirmed.label), \(Int(confirmed.duration))s",
+                                                 windowStart: confirmed.start,
+                                                 windowEnd: confirmed.end))
         return confirmed
     }
 

--- a/Atria/AtriaTests/AtriaCyclePatternTests.swift
+++ b/Atria/AtriaTests/AtriaCyclePatternTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import Atria
+
+/// Cycle-phase patterns (2026-07-07, design backlog item 10): the historical
+/// classifier must refuse to guess (no wrap past one cycle length, nothing
+/// before the first log) and the aggregation must gate on personalized data.
+final class AtriaCyclePatternTests: XCTestCase {
+    private var calendar: Calendar { Calendar(identifier: .gregorian) }
+
+    private func day(_ offset: Int, from base: Date) -> Date {
+        calendar.date(byAdding: .day, value: offset, to: base)!
+    }
+
+    @MainActor
+    private func makeStore(cycleStarts: [Int], base: Date) -> AtriaCycleTrackingStore {
+        // Isolated per-store temp directory: the default init reads/writes
+        // the real documents file, which leaks state across tests.
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cycle-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let store = AtriaCycleTrackingStore(directory: directory)
+        for offset in cycleStarts {
+            _ = store.logPeriodStart(day(offset, from: base), calendar: calendar)
+        }
+        return store
+    }
+
+    @MainActor
+    func testHistoricalDayBeforeFirstLogIsUnclassified() {
+        let base = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let store = makeStore(cycleStarts: [0, 28, 56], base: base)
+        XCTAssertNil(store.phaseEstimate(on: day(-5, from: base), calendar: calendar))
+    }
+
+    @MainActor
+    func testHistoricalDayNeverWrapsPastOneCycle() {
+        let base = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let store = makeStore(cycleStarts: [0], base: base)
+        // 40 days after the only logged start, with a 28-day default cycle:
+        // refuse to classify rather than wrap-guess.
+        XCTAssertNil(store.phaseEstimate(on: day(40, from: base), calendar: calendar))
+    }
+
+    @MainActor
+    func testEarlyCycleDaysClassifyMenstrualThenFollicular() {
+        let base = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let store = makeStore(cycleStarts: [0, 28, 56], base: base)
+        // Starts logged without explicit ends close at ~zero length, so the
+        // median period is 1 day: only the start day itself is menstrual.
+        XCTAssertEqual(store.phaseEstimate(on: day(56, from: base), calendar: calendar), .menstrual)
+        XCTAssertEqual(store.phaseEstimate(on: day(60, from: base), calendar: calendar), .follicular)
+    }
+
+    @MainActor
+    func testPatternsRequireTwoCompletedCycles() {
+        let base = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let store = makeStore(cycleStarts: [0], base: base)
+        let days = (0..<60).map { (day: day($0, from: base), recovery: Optional(70)) }
+        XCTAssertTrue(store.recoveryPatternsByPhase(days: days, now: day(59, from: base), calendar: calendar).isEmpty)
+    }
+
+    @MainActor
+    func testPatternsAggregatePerPhase() {
+        let base = calendar.startOfDay(for: Date(timeIntervalSince1970: 1_700_000_000))
+        let store = makeStore(cycleStarts: [0, 28, 56], base: base)
+        let days = (0..<84).map { (day: day($0, from: base), recovery: Optional(70)) }
+        let patterns = store.recoveryPatternsByPhase(days: days, now: day(83, from: base), calendar: calendar)
+        XCTAssertFalse(patterns.isEmpty)
+        XCTAssertTrue(patterns.allSatisfy { $0.averageRecovery == 70 && $0.dayCount >= 3 })
+    }
+}

--- a/Atria/AtriaTests/AtriaDetectionWindowTests.swift
+++ b/Atria/AtriaTests/AtriaDetectionWindowTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import Atria
+
+/// DetectionEvent structured windows (2026-07-07, design backlog item 11):
+/// the added optional window fields must round-trip and stay compatible with
+/// ring-buffer entries logged before the fields existed.
+final class AtriaDetectionWindowTests: XCTestCase {
+    func testWindowRoundTripsThroughCodable() throws {
+        let start = Date(timeIntervalSince1970: 1_700_000_000)
+        let event = DetectionEvent(kind: "workoutDetected",
+                                   detail: "fixture",
+                                   windowStart: start,
+                                   windowEnd: start.addingTimeInterval(1800))
+        let data = try JSONEncoder().encode(event)
+        let decoded = try JSONDecoder().decode(DetectionEvent.self, from: data)
+        XCTAssertEqual(decoded.windowStart, event.windowStart)
+        XCTAssertEqual(decoded.windowEnd, event.windowEnd)
+    }
+
+    func testLegacyEventWithoutWindowDecodes() throws {
+        // Shape of an entry persisted by a build that predates the fields.
+        let legacy = #"{"id":"11111111-2222-3333-4444-555555555555","kind":"workoutDetected","date":742000000,"detail":"legacy"}"#
+        let decoded = try JSONDecoder().decode(DetectionEvent.self, from: Data(legacy.utf8))
+        XCTAssertNil(decoded.windowStart)
+        XCTAssertNil(decoded.windowEnd)
+        XCTAssertEqual(decoded.kind, "workoutDetected")
+    }
+}

--- a/Atria/AtriaTests/AtriaFaceOffRHRTests.swift
+++ b/Atria/AtriaTests/AtriaFaceOffRHRTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+@testable import Atria
+
+/// Face-Off RHR row (2026-07-07): the payload's optional `h` field must
+/// round-trip through the link encoding, clamp against crafted values, and
+/// stay compatible with links minted before the field existed.
+final class AtriaFaceOffRHRTests: XCTestCase {
+    private func makePayload(h: Int?) -> AtriaFaceOffPayload {
+        AtriaFaceOffPayload(v: AtriaFaceOffPayload.currentVersion,
+                            name: "Sam",
+                            endEpochDay: 20_600,
+                            days: [.init(o: 0, r: 70, s: 8.5, z: 7.2, h: h)])
+    }
+
+    func testRestingHRRoundTripsThroughLink() throws {
+        let encoded = try XCTUnwrap(AtriaFaceOff.encode(makePayload(h: 55)))
+        let decoded = try XCTUnwrap(AtriaFaceOff.decode(encoded))
+        XCTAssertEqual(decoded.days.first?.h, 55)
+        XCTAssertEqual(decoded.averageRestingHR, 55)
+    }
+
+    func testLinkWithoutRestingHRStillDecodes() throws {
+        let encoded = try XCTUnwrap(AtriaFaceOff.encode(makePayload(h: nil)))
+        let decoded = try XCTUnwrap(AtriaFaceOff.decode(encoded))
+        XCTAssertNil(decoded.days.first?.h)
+        XCTAssertNil(decoded.averageRestingHR)
+        XCTAssertEqual(decoded.averageRecovery, 70)
+    }
+
+    func testCraftedRestingHRIsClamped() throws {
+        let encoded = try XCTUnwrap(AtriaFaceOff.encode(makePayload(h: 9999)))
+        let decoded = try XCTUnwrap(AtriaFaceOff.decode(encoded))
+        XCTAssertEqual(decoded.days.first?.h, 120)
+    }
+}

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -686,7 +686,9 @@ class HandoffStaticChecks(unittest.TestCase):
             "let priorAverageText: String?",
             "self.rangeText = metric.rangeText(low: low, high: high)",
             "AtriaTrendRangeSummaryStrip(summary: summary, tint: metric.tint)",
-            "summaryPill(label: \"Range\", value: summary.rangeText)",
+            # 2026-07-07 dedup audit: Range pill removed (position band
+            # states low/high with position context).
+            "summaryPill(label: \"Avg\", value: summary.averageText)",
             "summaryPill(label: \"Prior\", value: priorAverageText)",
             "AtriaTrendRangePositionBand(series: prepared.series,",
             "private struct AtriaTrendRangePositionBand: View, Equatable",
@@ -5745,7 +5747,9 @@ class HandoffStaticChecks(unittest.TestCase):
             ".accessibilityLabel(chartAccessibilityLabel)",
             "private var chartAccessibilityLabel: String",
             "\\(prepared.series.count) days in view.",
-            "Latest \\(summary.latestText), average \\(summary.averageText), range \\(summary.rangeText)",
+            # 2026-07-07 dedup audit: Latest/Range pills removed from the
+            # summary strip (position band owns them).
+            "Average \\(summary.averageText)",
             "private struct AtriaTrendPreparedSeries",
             "@State private var prepared = AtriaTrendPreparedSeries.empty",
             "@State private var periodReadout = AtriaTrendPeriodReadout.empty",
@@ -5814,7 +5818,9 @@ class HandoffStaticChecks(unittest.TestCase):
             "cuePill(title: \"Cue\"",
             "cuePill(title: \"Reserve\"",
             "cuePill(title: \"Load\"",
-            "Reserve \\(Int((readout.recoveryReserve * 100).rounded())) percent. Load \\(Int((readout.loadPressure * 100).rounded())) percent.",
+            # 2026-07-07 dedup audit: the report card's Reserve/Load bars
+            # moved to single ownership by the balance map.
+            "Balance map. Recovery reserve",
             "periodGauge(label: \"HRV\", delta: readout.hrv, tint: .cyan)",
             "periodGauge(label: \"Strain\", delta: readout.strain, tint: Metrics.electricStrain)",
             "private struct AtriaTrendPeriodReadout",
@@ -5861,15 +5867,19 @@ class HandoffStaticChecks(unittest.TestCase):
             "reportTile(strongestSignal)",
             "reportTile(pressureSignal)",
             "reportTile(nextStep)",
-            "reportBar(label: \"Res\", value: readout.recoveryReserve, tint: .cyan)",
-            "reportBar(label: \"Load\", value: readout.loadPressure, tint: Metrics.electricStrain)",
+            # 2026-07-07 dedup audit: the report card's Res/Load bars were
+            # the third rendering of the reserve/load pair in one stack —
+            # the balance map is now the single owner.
+            "reportTile(strongestSignal)",
             "Trend range report. Best signal",
             "private struct AtriaTrendPeriodBalanceMap: View, Equatable",
             "Label(\"Balance map\", systemImage: \"circle.grid.cross\")",
             "mapCorner(\"Ready\", alignment: .leading)",
             "mapCorner(\"Protect\", alignment: .trailing)",
-            "balancePill(\"Reserve\", value: readout.recoveryReserve, tint: .cyan)",
-            "balancePill(\"Load\", value: readout.loadPressure, tint: Metrics.electricStrain)",
+            # 2026-07-07 dedup audit: the balance map's pill row repeated
+            # the pair its 2D dot already encodes; the dot + a11y label are
+            # the single owner now.
+            "Balance map. Recovery reserve",
             "func directionScore(positiveDeltaIsGood: Bool) -> Double?",
             "private struct AtriaTrendSignalStack: View, Equatable",
             "Label(\"Signal stack\", systemImage: \"waveform.path\")",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -602,14 +602,17 @@ class HandoffStaticChecks(unittest.TestCase):
             "Text(item.segmentedLabel)",
             ".accessibilityLabel(item.menuLabel)",
             "@State private var rangeCoverage: [AtriaTrendRange: Int] = [:]",
-            "AtriaTrendRangeDock(selectedRange: $range,",
+            # 2026-07-07 dedup audit: the dock (a second control bound to
+            # the same $range as the segmented picker) is unmounted; its
+            # struct remains.
             "if periodReadout.hasEnoughSignal",
             "AtriaTrendPeriodBalanceMap(readout: periodReadout)",
             "AtriaTrendGlanceBoard(readout: periodReadout)",
             "AtriaTrendRangeReportCard(readout: periodReadout)",
             "private struct AtriaTrendGlanceBoard: View, Equatable",
-            "glanceLane(title: \"Recovery\"",
-            "glanceLane(title: \"Strain\"",
+            # 2026-07-07 dedup audit: the Recovery/Strain glance lanes were
+            # the third rendering of the reserve/load pair — the balance map
+            # owns it now; the board keeps its per-metric delta gauges.
             "metricGauge(label: \"HRV\", delta: readout.hrv, tint: .cyan)",
             "metricGauge(label: \"RHR\", delta: readout.restingHR, tint: .pink)",
             "metricGauge(label: \"Strain\", delta: readout.strain, tint: Metrics.electricStrain)",
@@ -659,7 +662,9 @@ class HandoffStaticChecks(unittest.TestCase):
             "var periodComparisonFloor: Double",
             "private static func prepareRangeCoverage(points: [AtriaTrendPoint]",
             "rangeCoverage = Self.prepareRangeCoverage(points: points,",
-            "AtriaTrendRangeDock(selectedRange: $range,",
+            # 2026-07-07 dedup audit: the dock (a second control bound to
+            # the same $range as the segmented picker) is unmounted; its
+            # struct remains.
             "private struct AtriaTrendRangeDock: View",
             "@Binding var selectedRange: AtriaTrendRange",
             "ForEach(AtriaTrendRange.allCases) { range in",
@@ -5761,7 +5766,9 @@ class HandoffStaticChecks(unittest.TestCase):
             # subtracting `range.days`.
             "range.hasPriorPeriod",
             "previousSeries: previousSamples",
-            "AtriaTrendRangeDock(selectedRange: $range,",
+            # 2026-07-07 dedup audit: the dock (a second control bound to
+            # the same $range as the segmented picker) is unmounted; its
+            # struct remains.
             "private struct AtriaTrendRangeDock: View",
             "Label(\"Ranges\", systemImage: \"calendar.badge.clock\")",
             "rangeNode(for: range)",
@@ -5797,8 +5804,9 @@ class HandoffStaticChecks(unittest.TestCase):
             "accessibilityLabel(assessment.accessibilityText)",
             "AtriaTrendGlanceBoard(readout: periodReadout)",
             "private struct AtriaTrendGlanceBoard: View, Equatable",
-            "glanceLane(title: \"Recovery\"",
-            "glanceLane(title: \"Strain\"",
+            # 2026-07-07 dedup audit: the Recovery/Strain glance lanes were
+            # the third rendering of the reserve/load pair — the balance map
+            # owns it now; the board keeps its per-metric delta gauges.
             "metricGauge(label: \"HRV\", delta: readout.hrv, tint: .cyan)",
             "metricGauge(label: \"RHR\", delta: readout.restingHR, tint: .pink)",
             "metricGauge(label: \"Strain\", delta: readout.strain, tint: Metrics.electricStrain)",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -9955,7 +9955,9 @@ class HandoffStaticChecks(unittest.TestCase):
         ]:
             assert_contains(self, health, needle)
         prepared_start = overview.index("private struct AtriaPreparedMetricHistory")
-        prepared_end = overview.index("private struct AtriaDetailChartPoint", prepared_start)
+        # 2026-07-07: chart point type became internal so the shared
+        # expanded-chart component (AtriaExpandedChart.swift) can consume it.
+        prepared_end = overview.index("struct AtriaDetailChartPoint", prepared_start)
         prepared_source = overview[prepared_start:prepared_end]
         assert_not_contains(self, overview, "dailyMetricHistory: store.dailyMetricHistory")
         assert_not_contains(self, overview, "let dailyMetricHistory: [SavedDailyMetric]")

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -8683,7 +8683,9 @@ class HandoffStaticChecks(unittest.TestCase):
             (health, 'AtriaHealthMetricRow(title: "Respiration",'),
             (strap, "struct AtriaStrapScreen: View"),
             (strap, 'Text("Strap")'),
-            (strap, 'AtriaStrapStatusRow(title: "Connection",'),
+            # 2026-07-07 dedup audit: the Connection row duplicated the
+            # state hero's value+detail verbatim and was removed.
+            (strap, 'connectionHero'),
             (strap, 'AtriaStrapStatusRow(title: "Battery",'),
             (strap, 'AtriaStrapStatusRow(title: "Mode",'),
             (strap, 'AtriaStrapStatusRow(title: "Session",'),

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -1096,7 +1096,9 @@ class HandoffStaticChecks(unittest.TestCase):
             "struct AtriaHeartRateAxisChart: View, Equatable",
             "let yDomain: ClosedRange<Int>",
             "lhs.points == rhs.points && lhs.yDomain == rhs.yDomain",
-            "AreaMark(x: .value(\"Time\", point.t),\n                     yStart: .value(\"Visible floor\", yDomain.lowerBound),\n                     yEnd: .value(\"BPM\", point.bpm))",
+            # 2026-07-07: the raw-line marks moved inside the smoothed/raw
+            # branch (HR smoothing, user feedback) — indentation deepened.
+            "AreaMark(x: .value(\"Time\", point.t),\n                             yStart: .value(\"Visible floor\", yDomain.lowerBound),\n                             yEnd: .value(\"BPM\", point.bpm))",
             ".chartXAxis",
             ".chartYAxis",
             ".chartXSelection(value: $selectedTime)",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -2564,7 +2564,9 @@ class HandoffStaticChecks(unittest.TestCase):
         assert_contains(self, live_workout, "Workout cue. \\(coachCueTitle). \\(coachCueDetail). Current zone")
         assert_contains(self, live_workout, "strainTargetCard")
         assert_contains(self, live_workout, "Text(\"Heart-rate zones\")")
-        assert_contains(self, live_workout, "Text(\"Z\\(zone.rawValue)\")")
+        # 2026-07-07 dedup audit: the coach-cue "Z<n>" chip was the third
+        # zone readout on one screen (hero caption + zone-bar chip remain),
+        # so its pin is retired with it.
         assert_contains(self, live_workout, "Text(\"Z\\(z.rawValue)\")")
         assert_contains(self, live_workout, "private var strainTargetCard: some View")
         assert_contains(self, live_workout, "Label(\"Target strain\", systemImage: \"target\")")
@@ -2576,7 +2578,8 @@ class HandoffStaticChecks(unittest.TestCase):
         assert_contains(self, live_workout, "arguments.contains(\"live-workout-target-build\")")
         assert_contains(self, live_workout, "arguments.contains(\"live-workout-target-hold\")")
         assert_contains(self, live_workout, "arguments.contains(\"live-workout-target-ease\")")
-        assert_contains(self, live_workout, "focusPill(title: \"Now\", value: String(format: \"%.1f\", strain))")
+        # 2026-07-07 dedup audit: the "Now" pill duplicated the stats row's
+        # Strain tile on the same HUD; the tile is the single live readout.
         assert_contains(self, live_workout, "focusPill(title: \"Target\", value: strainTargetValueText)")
         assert_contains(self, live_workout, "focusPill(title: \"Cue\", value: strainTargetCue)")
         assert_contains(self, live_workout, "Target strain. Current")


### PR DESCRIPTION
Completes the un-deferred design backlog plus two mid-loop feedback rounds (24 commits):

**Graph interactions (all charts)**
- Shared expanded landscape chart: rotated full-screen canvas, pinch/scroll zoom, drag-brush range selection with honest window summary, real workout/sleep marker lane — adopted by the six detail charts and the Vitals trends card
- Scrub companion tiles + "+N vs typical" callout delta; double-tap the scrubbed day to open its day-vs-median sheet
- "Range & interval" options sheet: manual bucket override (Auto/Daily/Week avg) + min–max band toggle
- Dense HR streams smooth into average + real min–max band past 150 samples (user feedback: raw 1 Hz line read as scribble)

**Dedup audit (workflow, ~30 findings; all highs + mediums fixed)**
- One owner per fact on: strap screen, live-workout HUD, weekly/monthly report heroes (now honesty-gated narratives), sleep detail (duration 4→1), trends insights (latest 3→1, reserve/load 3→1, dock unmounted), Today ring chip, strain target
- Vitals side-space reclaim: shared gutter 16→12, HR chart y-axis moved trailing (~28pt)

**New surfaces (honesty-gated throughout)**
- Strap connection hero with Scan + Connection guide; Activity Monitor 24h day timeline with pager
- Sleep-debt trend card (same math as the need ledger); strain zones histogram; per-workout HR trace; behaviors-that-move-you card (Welch-gated); Face-Off RHR row (wire-format compatible + tested); strain mix by activity type; cycle-phase recovery patterns (no-wrap classifier + tests); actionable workout detections (structured windows, additive + tested)

All 128 static checks + full unit suite green in an isolated worktree at the tip; every surface render- or screenshot-verified; installed on device throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)