### PR TITLE
ui-loop-6: forward-usability + fix loop (12 device-verified fixes)

### DIFF
--- a/Atria/Atria/AtriaActivityMonitor.swift
+++ b/Atria/Atria/AtriaActivityMonitor.swift
@@ -427,10 +427,15 @@ private struct AtriaActivityWorkoutDetailSheet: View {
         _endTime = State(initialValue: workout.end)
     }
 
-    /// The workout window's real recorded HR samples from the saved
-    /// sessions that overlap it. Empty when no session covered the window
-    /// (e.g. a manually added workout) — the card then doesn't render.
-    private var heartRateTracePoints: [AtriaHomeModel.HeartRateChartPoint] {
+    /// The workout window's real recorded HR samples from the saved sessions
+    /// that overlap it. Empty when no session covered the window (e.g. a manually
+    /// added workout) — the card then doesn't render. Cached in `tracePoints`
+    /// because this scan is O(sessions × points): recomputing it on every ~1 Hz
+    /// store publish while the sheet is open was a hang, and a completed workout's
+    /// overlapping samples never change (2026-07-08).
+    @State private var tracePoints: [AtriaHomeModel.HeartRateChartPoint] = []
+
+    private func computeHeartRateTracePoints() -> [AtriaHomeModel.HeartRateChartPoint] {
         store.sessions
             .filter { $0.end > workout.start && $0.start < workout.end }
             .flatMap { session in
@@ -448,7 +453,7 @@ private struct AtriaActivityWorkoutDetailSheet: View {
     /// band per the 2026-07-07 feedback.
     @ViewBuilder
     private var heartRateTraceCard: some View {
-        let points = heartRateTracePoints
+        let points = tracePoints
         if points.count >= 30 {
             VStack(alignment: .leading, spacing: 8) {
                 Text("Heart-rate trace")
@@ -618,6 +623,11 @@ private struct AtriaActivityWorkoutDetailSheet: View {
                 Button("Cancel", role: .cancel) {}
             } message: {
                 Text("Removes it from your history and strain. The recorded sensor data is kept; only this confirmed workout is deleted.")
+            }
+            // Compute the HR trace once per workout (samples are immutable for a
+            // completed workout) instead of rescanning all sessions each publish.
+            .task(id: workout.id) {
+                tracePoints = computeHeartRateTracePoints()
             }
         }
     }

--- a/Atria/Atria/AtriaActivityMonitor.swift
+++ b/Atria/Atria/AtriaActivityMonitor.swift
@@ -287,9 +287,20 @@ struct AtriaActivityMonitorTab: View {
                     title: workout.label,
                     subtitle: Self.timeRange(start: workout.start, end: workout.end),
                     value: Self.durationText(workout.duration),
-                    badge: workout.strain.map { "Strain \(String(format: "%.1f", $0))" }
-                        ?? "\(workout.avgHR) bpm avg")
+                    badge: Self.strainBadge(for: workout))
             .accessibilityLabel("\(workout.label), \(Self.durationText(workout.duration)), average \(workout.avgHR) bpm. Tap for details.")
+    }
+
+    /// Honesty (2026-07-08): strain is only as complete as the HR that covered
+    /// the window. A sparse-coverage window (e.g. a manually-added workout the
+    /// strap barely recorded) must NOT show a full-workout strain with no
+    /// signal — it reads as "83 min = 1.1 strain". Qualify or refuse the number.
+    static func strainBadge(for workout: UserConfirmedWorkout) -> String {
+        guard let strain = workout.strain else { return "\(workout.avgHR) bpm avg" }
+        if strain < 0.1 { return "No HR data" }
+        return workout.streamCoveragePercent < 75
+            ? "Strain \(String(format: "%.1f", strain)) \u{00b7} partial HR"
+            : "Strain \(String(format: "%.1f", strain))"
     }
 
     private func activityRow(icon: String,
@@ -560,10 +571,22 @@ private struct AtriaActivityWorkoutDetailSheet: View {
                         }
                     }
 
-                    Text("Times and stats come straight from the recorded session — nothing here is estimated or filled in.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    // Honesty (2026-07-08): when HR covered only part of the
+                    // window, say so — the strain reflects the covered minutes,
+                    // not the full entered duration. Otherwise the old caption
+                    // (now accurate) stands.
+                    if workout.streamCoveragePercent < 75 {
+                        Text("Strain reflects the \(Int((workout.observedDuration / 60).rounded())) min of strap heart-rate in this \(durationText(workout.duration)) window (\(workout.streamCoveragePercent)% covered) — the rest had no strap data, so it under-reads your full effort.")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                    } else {
+                        Text("Times and stats come straight from the recorded session — nothing here is estimated or filled in.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
 
                     Button(role: .destructive) {
                         showDeleteConfirm = true

--- a/Atria/Atria/AtriaAnalytics.swift
+++ b/Atria/Atria/AtriaAnalytics.swift
@@ -17,6 +17,13 @@ enum AtriaAnalytics {
 
             let start = first.timeIntervalSinceReferenceDate
             let relative = recent.map { ($0.t.timeIntervalSinceReferenceDate - start, $0.ms) }
+            // Fail closed on BLE-drop holes (device logs showed inter-beat gaps
+            // up to ~69s from 118 link disconnects). A large gap means missing
+            // beats; resampling across it manufactures slow low-frequency drift
+            // the periodogram would mislabel as breathing. 2026-07-08.
+            for index in 1..<relative.count where relative[index].0 - relative[index - 1].0 > 5.0 {
+                return nil
+            }
             let sampleRate = 4.0
             let step = 1.0 / sampleRate
             let count = Int(duration / step) + 1
@@ -51,7 +58,14 @@ enum AtriaAnalytics {
             var bestRate = 0.0
             var bestPower = 0.0
             var bandPower = 0.0
-            for breathsPerMinute in stride(from: 6.0, through: 30.0, by: 0.5) {
+            // Scan the respiratory HF band only (0.15-0.50 Hz = 9-30 bpm).
+            // The old 6 bpm floor (0.10 Hz) sat inside the HRV LF / Mayer-wave
+            // band, so at rest the LF/drift peak routinely won the argmax and
+            // the app reported ~6-8 bpm "breathing" — a fabricated number
+            // below any real resting rate. Raising the floor makes the SNR
+            // gate below evaluate prominence over the true breathing band and
+            // fail closed to "--" when only LF power is present. 2026-07-08.
+            for breathsPerMinute in stride(from: 9.0, through: 30.0, by: 0.5) {
                 let frequency = breathsPerMinute / 60.0
                 var real = 0.0
                 var imaginary = 0.0

--- a/Atria/Atria/AtriaAssistantScreen.swift
+++ b/Atria/Atria/AtriaAssistantScreen.swift
@@ -1,0 +1,231 @@
+import SwiftUI
+
+/// The Assistant, implemented (2026-07-07, user-directed — previously
+/// "Coming Soon"). Two honest layers:
+///
+/// 1. Question chips answered DETERMINISTICALLY from the app's own engines —
+///    the same numbers the rest of the app shows, never a language model,
+///    each answer stating where it came from and failing closed to a
+///    "still learning" line when the data isn't ready.
+/// 2. The existing provider-backed coach card (off by default, local/cloud
+///    opt-in with fabrication-flag auditing) for free-form summaries.
+struct AtriaAssistantScreen: View {
+    @ObservedObject var store: SessionStore
+    let context: AtriaCoachContext
+    let coachPayload: AtriaCoachPayload?
+    let aiCoachSettings: AtriaAICoachSettings
+    let aiCoachHasAPIKey: Bool
+    let onAICoachSettingsChange: (AtriaAICoachSettings) -> Void
+    let onSaveAICoachAPIKey: (String) -> Void
+    let onDeleteAICoachAPIKey: () -> Void
+
+    @AtriaDefault("atria.sleepPlanner.goal") private var plannerGoalRaw: String = AtriaSleepPlannerGoal.peak.rawValue
+    @AtriaDefault(AtriaWakeAlarmStore.wakeByMinutesKey) private var wakeByMinutes: Int = AtriaWakeAlarmPlan.defaultPlan.wakeByMinutes
+
+    private struct Exchange: Identifiable, Equatable {
+        let id = UUID()
+        let question: String
+        let answer: String
+        let provenance: String
+    }
+
+    private struct Prompt: Identifiable {
+        let id: String
+        let question: String
+    }
+
+    @State private var exchanges: [Exchange] = []
+
+    private static let prompts: [Prompt] = [
+        Prompt(id: "recovery", question: "Why is my recovery where it is?"),
+        Prompt(id: "sleep", question: "How much sleep do I need tonight?"),
+        Prompt(id: "typical", question: "What's typical for me?"),
+        Prompt(id: "behaviors", question: "What's been moving my recovery?"),
+        Prompt(id: "week", question: "How was my past week?"),
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            introBubble
+
+            ForEach(exchanges) { exchange in
+                exchangeBubbles(exchange)
+            }
+
+            promptChips
+
+            Divider()
+                .padding(.vertical, 4)
+
+            Text("FREE-FORM (OPTIONAL)")
+                .font(.caption2.weight(.black))
+                .foregroundStyle(.tertiary)
+                .kerning(0.8)
+            AtriaAICoachCard(context: context,
+                             preparedPayload: coachPayload,
+                             settings: aiCoachSettings,
+                             hasAPIKey: aiCoachHasAPIKey,
+                             onSettingsChange: onAICoachSettingsChange,
+                             onSaveAPIKey: onSaveAICoachAPIKey,
+                             onDeleteAPIKey: onDeleteAICoachAPIKey)
+        }
+        .padding(16)
+        .animation(.snappy(duration: 0.25), value: exchanges)
+    }
+
+    #if DEBUG
+    /// Test seam: the deterministic answer + provenance for a prompt id,
+    /// without going through a tap. Lets unit tests lock down the honesty
+    /// guarantee that every answer fails closed when the data isn't ready.
+    func debugAnswer(promptID: String) -> (answer: String, provenance: String) {
+        let exchange = answer(for: Prompt(id: promptID, question: ""))
+        return (exchange.answer, exchange.provenance)
+    }
+    #endif
+
+    private var introBubble: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Ask about your data")
+                .font(.headline.weight(.bold))
+            Text("These answers come straight from your own recorded data on this phone \u{2014} the same math behind every screen, nothing generated.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .atriaInsetCard(tint: .cyan)
+    }
+
+    private func exchangeBubbles(_ exchange: Exchange) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(exchange.question)
+                .font(.subheadline.weight(.semibold))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(.tint.opacity(0.16), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .frame(maxWidth: .infinity, alignment: .trailing)
+            VStack(alignment: .leading, spacing: 6) {
+                Text(exchange.answer)
+                    .font(.subheadline)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(exchange.provenance)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color(uiColor: .secondarySystemGroupedBackground),
+                        in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+    }
+
+    private var promptChips: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Self.prompts.filter { prompt in !exchanges.contains { $0.question == prompt.question } }) { prompt in
+                Button {
+                    exchanges.append(answer(for: prompt))
+                } label: {
+                    HStack {
+                        Text(prompt.question)
+                            .font(.subheadline.weight(.semibold))
+                        Spacer(minLength: 8)
+                        Image(systemName: "arrow.up.circle.fill")
+                            .foregroundStyle(.tint)
+                    }
+                    .padding(.horizontal, 14)
+                    .frame(minHeight: 44)
+                    .background(Color(uiColor: .secondarySystemGroupedBackground),
+                                in: Capsule(style: .continuous))
+                    .contentShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    // MARK: deterministic answers
+
+    private func answer(for prompt: Prompt) -> Exchange {
+        switch prompt.id {
+        case "recovery": return recoveryAnswer(prompt)
+        case "sleep": return sleepAnswer(prompt)
+        case "typical": return typicalAnswer(prompt)
+        case "behaviors": return behaviorsAnswer(prompt)
+        default: return weekAnswer(prompt)
+        }
+    }
+
+    private func recoveryAnswer(_ prompt: Prompt) -> Exchange {
+        let headline = context.guidance.headline.isEmpty ? context.guidance.detail : context.guidance.headline
+        let answer = context.recoveryText == "--"
+            ? "Your recovery is still learning \u{2014} it needs overnight baselines before it can score a morning."
+            : "Recovery is \(context.recoveryText). \(headline). Day strain so far is \(String(format: "%.1f", context.strain)) and HRV reads \(context.hrvText)."
+        return Exchange(question: prompt.question, answer: answer,
+                        provenance: "From today's recovery estimate and coach guidance.")
+    }
+
+    private func sleepAnswer(_ prompt: Prompt) -> Exchange {
+        let snapshot = store.sleepHistorySnapshot
+        guard let latest = snapshot.latest else {
+            return Exchange(question: prompt.question,
+                            answer: "No confirmed nights yet \u{2014} once Atria has a night of sleep, it can plan tonight.",
+                            provenance: "Sleep planner (needs at least one confirmed night).")
+        }
+        let baseNeed = SessionStore.configuredSleepBaseNeedHours()
+        let need = snapshot.sleepNeedHours(for: latest, baseNeedHours: baseNeed, yesterdayStrain: nil)
+        let goal = AtriaSleepPlannerGoal(rawValue: plannerGoalRaw) ?? .peak
+        let plan = AtriaSleepPlanner.plan(needHours: need, goal: goal, wakeByMinutes: wakeByMinutes,
+                                          nightEfficiencies: snapshot.nights.filter(\.confirmed).compactMap(\.sleepEfficiency))
+        return Exchange(question: prompt.question,
+                        answer: "Tonight's need is about \(AtriaMetricFormat.sleepHours(need)). For your \(goal.title) goal, aim to be in bed by \(plan.inBedByText) to get \(AtriaMetricFormat.sleepHours(plan.targetSleepHours)) asleep before your \(String(format: "%d:%02d", wakeByMinutes / 60, wakeByMinutes % 60)) wake-by time.",
+                        provenance: "Sleep planner: your need ledger, wake alarm, and \(plan.efficiencyIsDefault ? "a typical-population efficiency (still learning yours)" : "your own typical efficiency").")
+    }
+
+    private func typicalAnswer(_ prompt: Prompt) -> Exchange {
+        var lines: [String] = []
+        if let resting = store.baseline.restingInt { lines.append("resting HR \(resting) bpm") }
+        if let hrv = store.baseline.hrvInt { lines.append("overnight HRV around \(hrv) ms") }
+        guard !lines.isEmpty else {
+            return Exchange(question: prompt.question,
+                            answer: "Your personal baselines are still building \u{2014} they firm up after 14 nights of data.",
+                            provenance: "Personal baseline (learning).")
+        }
+        let trusted = store.baseline.hasTrustedRestingBaseline()
+        return Exchange(question: prompt.question,
+                        answer: "Typically for you: \(lines.joined(separator: ", ")).\(trusted ? "" : " These are still settling \u{2014} trusted after 14 nights.")",
+                        provenance: "Your personal baseline, learned from your own nights.")
+    }
+
+    private func behaviorsAnswer(_ prompt: Prompt) -> Exchange {
+        let impacts = Array(store.behaviorImpactSummariesCache.prefix(3))
+        guard !impacts.isEmpty else {
+            return Exchange(question: prompt.question,
+                            answer: "Nothing has cleared the statistical bar yet. Log journal tags on more days \u{2014} a behavior needs 5+ logged days and a real, unlikely-by-chance effect before it shows here.",
+                            provenance: "Behavior impact engine (no qualifying behaviors yet).")
+        }
+        let lines = impacts.map { "\($0.tag.label): \($0.valueText) across \($0.nightsText)" }
+        return Exchange(question: prompt.question,
+                        answer: lines.joined(separator: "\n"),
+                        provenance: "Your journal tags vs next-day recovery over 90 days. Association, not proof of cause.")
+    }
+
+    private func weekAnswer(_ prompt: Prompt) -> Exchange {
+        let report = WeeklyReport(rollups: store.dailyRollupHistory)
+        var parts: [String] = []
+        if let recovery = report.recoveryAvg {
+            let delta = report.recoveryDeltaVsPriorWeek.map { $0 >= 0 ? " (up \($0) on the prior week)" : " (down \(-$0) on the prior week)" } ?? ""
+            parts.append("recovery averaged \(recovery)%\(delta)")
+        }
+        if let strain = report.strainAvg, strain > 0 { parts.append(String(format: "daily strain averaged %.1f", strain)) }
+        if let sleep = report.sleepAvgSeconds, sleep > 0 { parts.append("sleep averaged \(SleepHistorySnapshot.formatDuration(sleep)) a night") }
+        guard !parts.isEmpty else {
+            return Exchange(question: prompt.question,
+                            answer: "Not enough recorded days this week to summarize yet.",
+                            provenance: "Weekly report (building).")
+        }
+        return Exchange(question: prompt.question,
+                        answer: "This week: \(parts.joined(separator: "; ")).",
+                        provenance: "Your weekly report, computed from daily rollups.")
+    }
+}

--- a/Atria/Atria/AtriaAssistantScreen.swift
+++ b/Atria/Atria/AtriaAssistantScreen.swift
@@ -158,7 +158,11 @@ struct AtriaAssistantScreen: View {
 
     private func recoveryAnswer(_ prompt: Prompt) -> Exchange {
         let headline = context.guidance.headline.isEmpty ? context.guidance.detail : context.guidance.headline
-        let answer = context.recoveryText == "--"
+        // Production emits "Learning" (not "--") from HeroSnapshot.recoveryValue
+        // when there's no score yet; guard on both so the still-learning line
+        // isn't dead code and we never build a "Recovery is Learning." sentence.
+        let recoveryReady = context.recoveryText != "Learning" && context.recoveryText != "--"
+        let answer = !recoveryReady
             ? "Your recovery is still learning \u{2014} it needs overnight baselines before it can score a morning."
             : "Recovery is \(context.recoveryText). \(headline). Day strain so far is \(String(format: "%.1f", context.strain)) and HRV reads \(context.hrvText)."
         return Exchange(question: prompt.question, answer: answer,

--- a/Atria/Atria/AtriaExpandedChart.swift
+++ b/Atria/Atria/AtriaExpandedChart.swift
@@ -27,9 +27,14 @@ struct AtriaExpandedChartView: View {
     var priorPoints: [AtriaDetailChartPoint] = []
     var baselineBand: AtriaDetailBaselineBand? = nil
     var events: [AtriaChartEvent] = []
+    /// Sibling series offered as an overlay ("Edit this chart", design
+    /// handoff). One at a time; the overlay is rescaled into this chart's
+    /// y-domain and the legend says so — comparison of shape, not units.
+    var overlays: [(title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint])] = []
     let onDismiss: () -> Void
 
     @State private var visibleDays: Int = 0
+    @State private var activeOverlayTitle: String?
     @State private var brushStart: Date?
     @State private var brushEnd: Date?
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -124,6 +129,17 @@ struct AtriaExpandedChartView: View {
                     .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [4, 4]))
             }
 
+            if let overlay = activeOverlay {
+                ForEach(rescaledOverlayPoints(overlay)) { point in
+                    LineMark(x: .value("Day", point.day, unit: .day),
+                             y: .value(title, point.value),
+                             series: .value("Series", "overlay"))
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(overlay.tint.opacity(0.7))
+                        .lineStyle(StrokeStyle(lineWidth: 1.5, dash: [6, 3]))
+                }
+            }
+
             ForEach(points) { point in
                 LineMark(x: .value("Day", point.day, unit: .day),
                          y: .value(title, point.value),
@@ -184,7 +200,29 @@ struct AtriaExpandedChartView: View {
     }
 
     private var footer: some View {
-        HStack(spacing: 14) {
+        HStack(spacing: 10) {
+            if !overlays.isEmpty {
+                ForEach(overlays, id: \.title) { overlay in
+                    let isActive = activeOverlayTitle == overlay.title
+                    Button {
+                        activeOverlayTitle = isActive ? nil : overlay.title
+                    } label: {
+                        Text(overlay.title)
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(isActive ? overlay.tint : .secondary)
+                            .padding(.horizontal, 9)
+                            .frame(minHeight: 30)
+                            .background((isActive ? overlay.tint : Color.secondary).opacity(0.14), in: Capsule(style: .continuous))
+                            .contentShape(Capsule())
+                    }
+                    .accessibilityLabel("\(isActive ? "Hide" : "Overlay") \(overlay.title)")
+                }
+                if activeOverlay != nil {
+                    Text("dashed \u{00b7} scaled to fit")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
             if !events.isEmpty {
                 Label("\(events.count) activities marked", systemImage: "flag.fill")
                     .font(.caption2.weight(.semibold))
@@ -194,6 +232,28 @@ struct AtriaExpandedChartView: View {
             Text("\(min(visibleDays, spanDays)) of \(spanDays) days visible")
                 .font(.caption2.monospacedDigit())
                 .foregroundStyle(.tertiary)
+        }
+    }
+
+    private var activeOverlay: (title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint])? {
+        overlays.first { $0.title == activeOverlayTitle }
+    }
+
+    /// Maps the overlay's values from its own min-max into this chart's
+    /// y-domain: an honest SHAPE comparison (the dashed line + "scaled to
+    /// fit" caption make clear the units differ).
+    private func rescaledOverlayPoints(_ overlay: (title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint])) -> [AtriaDetailChartPoint] {
+        let values = overlay.points.map(\.value)
+        guard let lo = values.min(), let hi = values.max(), hi > lo else { return [] }
+        let domain = yDomain
+        let pad = (domain.upperBound - domain.lowerBound) * 0.06
+        let targetLo = domain.lowerBound + pad
+        let targetHi = domain.upperBound - pad
+        return overlay.points.map { point in
+            let fraction = (point.value - lo) / (hi - lo)
+            return AtriaDetailChartPoint(day: point.day,
+                                         value: targetLo + fraction * (targetHi - targetLo),
+                                         tint: overlay.tint)
         }
     }
 

--- a/Atria/Atria/AtriaHealthScreen.swift
+++ b/Atria/Atria/AtriaHealthScreen.swift
@@ -568,47 +568,80 @@ struct AtriaHealthScreen: View {
     /// scored readings since the app has been reading, as an area strip with
     /// the Medium/High thresholds marked. In-memory history — stretches with
     /// no reading are real gaps, and under 10 minutes of data shows nothing.
-    @ViewBuilder
-    private var stressHistoryStrip: some View {
+    private struct StressStripPoint: Identifiable {
+        let id: Int
+        let t: Date
+        let value: Double
+        let segment: Int
+    }
+
+    /// Session stress split into contiguous runs: a gap longer than 5 minutes
+    /// (well beyond the ~30s recording cadence) starts a new SERIES so Swift
+    /// Charts leaves a REAL blank instead of interpolating a straight line
+    /// across a stretch the strap wasn't read — the honesty contract the
+    /// store comments promise. Computed off the render path (2026-07-08).
+    private var stressStripPoints: [StressStripPoint] {
         let history = stressMonitorStore.history
-        if let first = history.first, let last = history.last,
-           last.t.timeIntervalSince(first.t) >= 10 * 60 {
-            VStack(alignment: .leading, spacing: 6) {
-                Chart(history) { point in
-                    AreaMark(x: .value("Time", point.t),
-                             y: .value("Stress", point.activation * 3))
-                        .interpolationMethod(.monotone)
-                        .foregroundStyle(point.level.tint.opacity(0.25))
-                    LineMark(x: .value("Time", point.t),
-                             y: .value("Stress", point.activation * 3))
-                        .interpolationMethod(.monotone)
-                        .foregroundStyle(.orange.gradient)
-                    RuleMark(y: .value("Medium", 1))
-                        .foregroundStyle(.secondary.opacity(0.25))
-                        .lineStyle(StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
-                    RuleMark(y: .value("High", 2))
-                        .foregroundStyle(.secondary.opacity(0.25))
-                        .lineStyle(StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
-                }
-                .chartYScale(domain: 0...3)
-                .chartYAxis(.hidden)
-                .chartXAxis {
-                    AxisMarks(values: .automatic(desiredCount: 3)) { _ in
-                        AxisValueLabel(format: .dateTime.hour().minute())
-                    }
-                }
-                .frame(height: 56)
-                .clipped()
-                Text("Stress while Atria has been reading today \u{00b7} dashes mark Medium and High")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
+        guard history.count > 1 else { return [] }
+        var points: [StressStripPoint] = []
+        points.reserveCapacity(history.count)
+        var segment = 0
+        for (index, point) in history.enumerated() {
+            if index > 0, point.t.timeIntervalSince(history[index - 1].t) > 5 * 60 {
+                segment += 1
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 8)
-            .background(Color(uiColor: .tertiarySystemGroupedBackground),
-                        in: RoundedRectangle(cornerRadius: 12, style: .continuous))
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Stress history for this session, \(history.count) readings.")
+            points.append(StressStripPoint(id: index, t: point.t,
+                                           value: point.activation * 3, segment: segment))
+        }
+        return points
+    }
+
+    private var stressHistoryStrip: some View {
+        let points = stressStripPoints
+        return Group {
+            if let first = points.first, let last = points.last,
+               last.t.timeIntervalSince(first.t) >= 10 * 60 {
+                VStack(alignment: .leading, spacing: 6) {
+                    Chart {
+                        ForEach(points) { point in
+                            AreaMark(x: .value("Time", point.t),
+                                     y: .value("Stress", point.value),
+                                     series: .value("Segment", point.segment))
+                                .interpolationMethod(.monotone)
+                                .foregroundStyle(.orange.opacity(0.16))
+                            LineMark(x: .value("Time", point.t),
+                                     y: .value("Stress", point.value),
+                                     series: .value("Segment", point.segment))
+                                .interpolationMethod(.monotone)
+                                .foregroundStyle(.orange.gradient)
+                        }
+                        RuleMark(y: .value("Medium", 1))
+                            .foregroundStyle(.secondary.opacity(0.25))
+                            .lineStyle(StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
+                        RuleMark(y: .value("High", 2))
+                            .foregroundStyle(.secondary.opacity(0.25))
+                            .lineStyle(StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
+                    }
+                    .chartYScale(domain: 0...3)
+                    .chartYAxis(.hidden)
+                    .chartXAxis {
+                        AxisMarks(values: .automatic(desiredCount: 3)) { _ in
+                            AxisValueLabel(format: .dateTime.hour().minute())
+                        }
+                    }
+                    .frame(height: 56)
+                    .clipped()
+                    Text("Stress while Atria has been reading today \u{00b7} gaps where the strap wasn't read stay blank")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
+                .background(Color(uiColor: .tertiarySystemGroupedBackground),
+                            in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Stress history for this session, \(points.count) readings.")
+            }
         }
     }
 

--- a/Atria/Atria/AtriaHealthScreen.swift
+++ b/Atria/Atria/AtriaHealthScreen.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Charts
 
 struct AtriaHealthScreen: View {
     #if DEBUG
@@ -310,6 +311,7 @@ struct AtriaHealthScreen: View {
                                      tint: stressTint,
                                      hint: stressHint,
                                      onTap: { educationTopic = .stress })
+                stressHistoryStrip
             }
             .opacity(isDisconnected && latestRollup != nil ? 0.65 : 1)
 
@@ -560,6 +562,54 @@ struct AtriaHealthScreen: View {
 
     private var stressDetail: String {
         stressMonitorStore.state.detail.isEmpty ? stressMonitorStore.state.label : stressMonitorStore.state.detail
+    }
+
+    /// Session stress timeline (WHOOP-research follow-up 2026-07-07): the
+    /// scored readings since the app has been reading, as an area strip with
+    /// the Medium/High thresholds marked. In-memory history — stretches with
+    /// no reading are real gaps, and under 10 minutes of data shows nothing.
+    @ViewBuilder
+    private var stressHistoryStrip: some View {
+        let history = stressMonitorStore.history
+        if let first = history.first, let last = history.last,
+           last.t.timeIntervalSince(first.t) >= 10 * 60 {
+            VStack(alignment: .leading, spacing: 6) {
+                Chart(history) { point in
+                    AreaMark(x: .value("Time", point.t),
+                             y: .value("Stress", point.activation * 3))
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(point.level.tint.opacity(0.25))
+                    LineMark(x: .value("Time", point.t),
+                             y: .value("Stress", point.activation * 3))
+                        .interpolationMethod(.monotone)
+                        .foregroundStyle(.orange.gradient)
+                    RuleMark(y: .value("Medium", 1))
+                        .foregroundStyle(.secondary.opacity(0.25))
+                        .lineStyle(StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
+                    RuleMark(y: .value("High", 2))
+                        .foregroundStyle(.secondary.opacity(0.25))
+                        .lineStyle(StrokeStyle(lineWidth: 0.5, dash: [3, 3]))
+                }
+                .chartYScale(domain: 0...3)
+                .chartYAxis(.hidden)
+                .chartXAxis {
+                    AxisMarks(values: .automatic(desiredCount: 3)) { _ in
+                        AxisValueLabel(format: .dateTime.hour().minute())
+                    }
+                }
+                .frame(height: 56)
+                .clipped()
+                Text("Stress while Atria has been reading today \u{00b7} dashes mark Medium and High")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background(Color(uiColor: .tertiarySystemGroupedBackground),
+                        in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Stress history for this session, \(history.count) readings.")
+        }
     }
 
     private var stressTint: Color {

--- a/Atria/Atria/AtriaHomeView.swift
+++ b/Atria/Atria/AtriaHomeView.swift
@@ -670,6 +670,7 @@ struct AtriaHomeView: View {
         .sheet(isPresented: $showSettings) {
             AtriaSettingsView(profile: model.profileStore.profile,
                               restingBaseline: store.baseline.restingInt,
+                              myWeeklyRecovery: WeeklyReport(rollups: store.dailyRollupHistory).recoveryAvg,
                               strapName: ble.resolvedDeviceName,
                               strapModel: ble.strapModelLabel,
                               strapGenerationDetail: ble.strapGenerationDetail,

--- a/Atria/Atria/AtriaHomeView.swift
+++ b/Atria/Atria/AtriaHomeView.swift
@@ -1998,11 +1998,15 @@ struct AtriaHomeView: View {
         // newest confirmed sleep is already recent.
         store.autoConfirmSleepOnForegroundIfUseful(reason: "scene_foreground")
         Task { await AtriaResearchUploadQueue.runForegroundCatchUpIfMissed(store: store) }
-        LocalNotificationScheduler.scheduleEveningJournalCheckIn(
-            lastJournalActivity: [store.behaviorJournalEntries.map(\.day).max(),
-                                  store.journalAnswers.latestActivityDay()]
-                .compactMap { $0 }
-                .max())
+        let lastJournalActivity = [store.behaviorJournalEntries.map(\.day).max(),
+                                   store.journalAnswers.latestActivityDay()]
+            .compactMap { $0 }
+            .max()
+        LocalNotificationScheduler.scheduleEveningJournalCheckIn(lastJournalActivity: lastJournalActivity)
+        // Pre-schedule the morning journal nudge too, so a waking user gets a
+        // check-in prompt even when last night's sleep wasn't confirmed and the
+        // rich morning summary is skipped (user 2026-07-08).
+        LocalNotificationScheduler.scheduleMorningJournalCheckIn(lastJournalActivity: lastJournalActivity)
     }
 
     private func refreshAICoachKeyState() {

--- a/Atria/Atria/AtriaHomeView.swift
+++ b/Atria/Atria/AtriaHomeView.swift
@@ -815,12 +815,25 @@ struct AtriaHomeView: View {
                 }
             }
         }
-        // Assistant moved out of the bottom bar (it's still "Coming Soon"); it
-        // now opens from a top-right icon, mirroring how Strap is presented.
+        // Assistant implemented (2026-07-07, user-directed): deterministic
+        // Q&A from the app's own engines + the opt-in provider coach card.
         .fullScreenCover(isPresented: $showAssistant) {
             NavigationStack {
                 ScrollView {
-                    chatComingSoonContent
+                    AtriaAssistantScreen(store: store,
+                                         context: assistantCoachContext,
+                                         coachPayload: assistantCoachPayload,
+                                         aiCoachSettings: aiCoachSettings,
+                                         aiCoachHasAPIKey: aiCoachHasAPIKey,
+                                         onAICoachSettingsChange: { aiCoachSettings = $0 },
+                                         onSaveAICoachAPIKey: { key in
+                                             AtriaCoachKeychain.saveAPIKey(key, provider: aiCoachSettings.cloudProvider)
+                                             aiCoachHasAPIKey = true
+                                         },
+                                         onDeleteAICoachAPIKey: {
+                                             AtriaCoachKeychain.deleteAPIKey(provider: aiCoachSettings.cloudProvider)
+                                             aiCoachHasAPIKey = false
+                                         })
                 }
                 .scrollContentBackground(.hidden)
                 .background {
@@ -2120,28 +2133,32 @@ struct AtriaHomeView: View {
 #endif
     }
 
-    private var chatComingSoonContent: some View {
-        VStack(spacing: 14) {
-            Image(systemName: "bubble.left.and.bubble.right.fill")
-                .font(.system(size: 44, weight: .semibold))
-                .foregroundStyle(.tint)
-                .padding(.top, 48)
-            Text("ATRIA Intelligent Assistant")
-                .font(.title2.weight(.bold))
-            Text("Coming Soon!")
-                .font(.headline)
-                .foregroundStyle(.secondary)
-            Text("Ask your recovery, sleep and strain anything — answered from your own data, on this phone.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, 28)
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.vertical, 28)
-        .atriaCard()
-        .padding(.horizontal, 16)
+    /// Context for the Assistant's deterministic answers — the same hero
+    /// state the Today screen feeds its coach card.
+    private var assistantCoachContext: AtriaCoachContext {
+        let hero = model.heroStore.state
+        return AtriaCoachContext(guidance: hero.guidance,
+                                 strain: hero.strain,
+                                 recoveryText: hero.recoveryValue,
+                                 hrvText: hero.hrvValue,
+                                 stressText: hero.stressValue,
+                                 baselineSamples: hero.baselineSamples,
+                                 sessionsCount: hero.sessionsCount)
     }
+
+    /// Built on demand — the assistant cover opens rarely, so a fresh
+    /// last-7 payload is fine (same builder + baselines as the Today card).
+    private var assistantCoachPayload: AtriaCoachPayload? {
+        AtriaCoachPayload.fromRollups(rollups: Array(store.dailyRollupHistory.prefix(7)),
+                                      fallback: assistantCoachContext,
+                                      baselines: [
+                                          "recovery": .init(low: 0, high: 100),
+                                          "strain": .init(low: 0, high: model.heroStore.state.guidance.target ?? 20),
+                                          "hrv": .init(low: nil, high: nil),
+                                          "rhr": .init(low: nil, high: nil)
+                                      ])
+    }
+
 
     private var topChrome: some View {
         AtriaHomeTopChrome(statusStore: model.statusStore,

--- a/Atria/Atria/AtriaHomeView.swift
+++ b/Atria/Atria/AtriaHomeView.swift
@@ -6286,17 +6286,18 @@ final class AtriaHomeModel {
     }
 
     private func publishPulseSparkline() {
-        let next = Self.makePulseSparklineState(ble: ble)
-        guard next != pulseSparklineStore.state else { return }
-        // The chart buckets per second, but RR/HR arrive several times a second —
-        // publishing each beat re-merged and re-laid-out the Swift Charts
-        // timeline per heartbeat. 1 Hz is the chart's native resolution; the
-        // hero BPM digit stays on the un-gated pulseLiveStore so perceived
-        // liveness is unchanged. Staleness is bounded: the next beat after the
-        // window publishes.
+        // Throttle FIRST (2026-07-08 perf audit): the chart buckets per second,
+        // but RR/HR arrive several times a second, and makePulseSparklineState
+        // (suffix + filter + stride) plus the ~120-element Equatable compare
+        // were running on EVERY beat before this gate. 1 Hz is the chart's
+        // native resolution; the hero BPM digit stays on the un-gated
+        // pulseLiveStore so perceived liveness is unchanged. Staleness is
+        // bounded: the next beat after the window publishes.
         let now = Date()
         guard now.timeIntervalSince(lastPulseSparklinePublishAt) >= 1.0 else { return }
         lastPulseSparklinePublishAt = now
+        let next = Self.makePulseSparklineState(ble: ble)
+        guard next != pulseSparklineStore.state else { return }
         pulseSparklineStore.state = next
     }
 

--- a/Atria/Atria/AtriaHomeView.swift
+++ b/Atria/Atria/AtriaHomeView.swift
@@ -2086,6 +2086,26 @@ struct AtriaHomeView: View {
                             .transition(.move(edge: .top).combined(with: .opacity))
                     }
                 }
+                .background {
+                    // Occluding scrim (2026-07-08, device-reported): the chrome
+                    // band is transparent between the status chip and the icon
+                    // buttons, so scrolled content bled through behind them
+                    // ("This week", glance rows showing through the pill). A
+                    // thin top-anchored fade — NOT a second full AtriaBackdropLayer
+                    // (overdraw trap) — occludes content under the band and
+                    // dissolves it into the page at the lower edge.
+                    LinearGradient(
+                        stops: [
+                            .init(color: Color(.systemBackground), location: 0.0),
+                            .init(color: Color(.systemBackground), location: 0.62),
+                            .init(color: Color(.systemBackground).opacity(0), location: 1.0)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                    .ignoresSafeArea(edges: .top)
+                    .allowsHitTesting(false)
+                }
             }
             .safeAreaInset(edge: .bottom, spacing: 0) {
                 Color.clear

--- a/Atria/Atria/AtriaJournalStore.swift
+++ b/Atria/Atria/AtriaJournalStore.swift
@@ -228,6 +228,11 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
     case alcoholDrinks = "alcohol.drinks"
     case moodScale = "mood.scale"
     case stressScale = "stress.scale"
+    // Subjective outcomes (2026-07-08): daily energy + focus. Both scale 1→5 =
+    // depleted→energized / scattered→sharp, matching the emoji scale, so the
+    // insight engine can correlate them with recovery/sleep/strain over time.
+    case energyScale = "energy.scale"
+    case focusScale = "focus.scale"
 
     var id: String { rawValue }
 
@@ -237,6 +242,8 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
         case .alcoholDrinks: return "How many drinks?"
         case .moodScale: return "How's your mood today?"
         case .stressScale: return "How stressed do you feel?"
+        case .energyScale: return "How's your energy today?"
+        case .focusScale: return "How sharp is your focus?"
         }
     }
 
@@ -246,6 +253,8 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
         case .alcoholDrinks: return "wineglass"
         case .moodScale: return "face.smiling"
         case .stressScale: return "bolt.heart"
+        case .energyScale: return "bolt.fill"
+        case .focusScale: return "target"
         }
     }
 
@@ -256,6 +265,8 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
         case .alcoholDrinks: return "drinks"
         case .moodScale: return "mood"
         case .stressScale: return "stress"
+        case .energyScale: return "energy"
+        case .focusScale: return "focus"
         }
     }
 
@@ -264,7 +275,7 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
         switch self {
         case .caffeineLastTime: return .caffeine
         case .alcoholDrinks: return .alcohol
-        case .moodScale, .stressScale: return nil
+        case .moodScale, .stressScale, .energyScale, .focusScale: return nil
         }
     }
 }

--- a/Atria/Atria/AtriaJournalStore.swift
+++ b/Atria/Atria/AtriaJournalStore.swift
@@ -233,6 +233,12 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
     // insight engine can correlate them with recovery/sleep/strain over time.
     case energyScale = "energy.scale"
     case focusScale = "focus.scale"
+    // Habit behavior (2026-07-08): evening wind-down / sleep hygiene, scale 1→5 =
+    // wired→relaxed. A daily behavior the user can build a habit around, and the
+    // insight engine can correlate with sleep + recovery ("you sleep better on
+    // well-wound-down nights") — water/nutrition/caffeine are already tracked, so
+    // this fills a genuine gap rather than duplicating.
+    case windDownScale = "winddown.scale"
 
     var id: String { rawValue }
 
@@ -244,6 +250,7 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
         case .stressScale: return "How stressed do you feel?"
         case .energyScale: return "How's your energy today?"
         case .focusScale: return "How sharp is your focus?"
+        case .windDownScale: return "How well did you wind down?"
         }
     }
 
@@ -255,6 +262,7 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
         case .stressScale: return "bolt.heart"
         case .energyScale: return "bolt.fill"
         case .focusScale: return "target"
+        case .windDownScale: return "moon.zzz"
         }
     }
 
@@ -267,6 +275,7 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
         case .stressScale: return "stress"
         case .energyScale: return "energy"
         case .focusScale: return "focus"
+        case .windDownScale: return "wind-down"
         }
     }
 
@@ -275,7 +284,7 @@ enum AtriaJournalTypedQuestion: String, CaseIterable, Identifiable {
         switch self {
         case .caffeineLastTime: return .caffeine
         case .alcoholDrinks: return .alcohol
-        case .moodScale, .stressScale, .energyScale, .focusScale: return nil
+        case .moodScale, .stressScale, .energyScale, .focusScale, .windDownScale: return nil
         }
     }
 }

--- a/Atria/Atria/AtriaJournalTab.swift
+++ b/Atria/Atria/AtriaJournalTab.swift
@@ -826,7 +826,8 @@ private struct AtriaJournalCheckInDeck: View {
 }
 
 /// 90-day logging history: one cell per day, brightness by how much was logged.
-private struct AtriaJournalHeatStrip: View, Equatable {
+// Internal (was private) so the empty-vs-full history modes are render-testable.
+struct AtriaJournalHeatStrip: View, Equatable {
     let entries: [BehaviorJournalEntry]
 
     static func == (lhs: AtriaJournalHeatStrip, rhs: AtriaJournalHeatStrip) -> Bool {
@@ -859,12 +860,34 @@ private struct AtriaJournalHeatStrip: View, Equatable {
         return days.filter { (counts[$0] ?? 0) > 0 }.count
     }
 
+    /// The full 90-day grid only earns its space once there's enough history to
+    /// show a pattern; before that it's ~88 empty cells advertising emptiness
+    /// (UX audit 2026-07-08). Until ~3 weeks of history, show a 2-week strip.
+    private static let compactDayCount = 14
+    private var hasEnoughHistoryForFullGrid: Bool {
+        guard let earliest = entries.map({ Calendar.current.startOfDay(for: $0.day) }).min() else { return false }
+        let span = Calendar.current.dateComponents([.day], from: earliest,
+                                                    to: Calendar.current.startOfDay(for: Date())).day ?? 0
+        return span >= 21
+    }
+
+    private var recentDays: [Date] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        return (0..<Self.compactDayCount).compactMap {
+            calendar.date(byAdding: .day, value: -(Self.compactDayCount - 1 - $0), to: today)
+        }
+    }
+
     var body: some View {
         let counts = countsByDay
+        let fullGrid = hasEnoughHistoryForFullGrid
+        let shownDays = fullGrid ? days : recentDays
+        let columnCount = fullGrid ? 30 : Self.compactDayCount
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 12) {
                 AtriaPanelSectionHeader(title: "Logging history",
-                                        subtitle: "Last 90 days")
+                                        subtitle: fullGrid ? "Last 90 days" : "Last 2 weeks")
 
                 Spacer(minLength: 0)
 
@@ -873,16 +896,24 @@ private struct AtriaJournalHeatStrip: View, Equatable {
                                 tint: .cyan)
             }
 
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 3), count: 30),
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 3), count: columnCount),
                       spacing: 3) {
-                ForEach(days, id: \.self) { day in
+                ForEach(shownDays, id: \.self) { day in
                     RoundedRectangle(cornerRadius: 1.5, style: .continuous)
                         .fill(cellColor(count: counts[day] ?? 0))
                         .aspectRatio(1, contentMode: .fit)
                 }
             }
             .accessibilityElement(children: .ignore)
-            .accessibilityLabel("Journal logging history: \(loggedDayCount) of the last \(Self.dayCount) days logged.")
+            .accessibilityLabel("Journal logging history: \(loggedDayCount) of the last \(fullGrid ? Self.dayCount : Self.compactDayCount) days logged.")
+
+            if !fullGrid {
+                Text(loggedDayCount == 0
+                     ? "Log today to start your pattern — the full 90-day view builds as history grows."
+                     : "Your full 90-day pattern unlocks as history builds.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
         }
         .padding(16)
         .atriaCard(emphasis: .soft)

--- a/Atria/Atria/AtriaJournalTab.swift
+++ b/Atria/Atria/AtriaJournalTab.swift
@@ -331,7 +331,7 @@ private struct AtriaJournalCheckInDeck: View {
 
     private var tags: [BehaviorJournalEntry.Tag] { BehaviorJournalEntry.Tag.allCases }
     /// Standalone typed cards appended after the boolean tags.
-    private var scaleQuestions: [AtriaJournalTypedQuestion] { [.moodScale, .stressScale] }
+    private var scaleQuestions: [AtriaJournalTypedQuestion] { [.moodScale, .stressScale, .energyScale, .focusScale] }
     private var cardCount: Int { tags.count + scaleQuestions.count }
     private var answeredCount: Int { answeredTagCount + answeredScaleCount }
     private var answeredScaleCount: Int {
@@ -719,7 +719,7 @@ private struct AtriaJournalCheckInDeck: View {
                     pendingDrinks = existing
                 }
             }
-        case .moodScale, .stressScale:
+        case .moodScale, .stressScale, .energyScale, .focusScale:
             EmptyView()
         }
     }

--- a/Atria/Atria/AtriaJournalTab.swift
+++ b/Atria/Atria/AtriaJournalTab.swift
@@ -331,7 +331,7 @@ private struct AtriaJournalCheckInDeck: View {
 
     private var tags: [BehaviorJournalEntry.Tag] { BehaviorJournalEntry.Tag.allCases }
     /// Standalone typed cards appended after the boolean tags.
-    private var scaleQuestions: [AtriaJournalTypedQuestion] { [.moodScale, .stressScale, .energyScale, .focusScale] }
+    private var scaleQuestions: [AtriaJournalTypedQuestion] { [.moodScale, .stressScale, .energyScale, .focusScale, .windDownScale] }
     private var cardCount: Int { tags.count + scaleQuestions.count }
     private var answeredCount: Int { answeredTagCount + answeredScaleCount }
     private var answeredScaleCount: Int {
@@ -719,7 +719,7 @@ private struct AtriaJournalCheckInDeck: View {
                     pendingDrinks = existing
                 }
             }
-        case .moodScale, .stressScale, .energyScale, .focusScale:
+        case .moodScale, .stressScale, .energyScale, .focusScale, .windDownScale:
             EmptyView()
         }
     }

--- a/Atria/Atria/AtriaLeaderboardScreen.swift
+++ b/Atria/Atria/AtriaLeaderboardScreen.swift
@@ -1,0 +1,180 @@
+import SwiftUI
+
+/// Leaderboard (2026-07-08, user-requested P3, DEMO). No backend is connected
+/// yet, so this is an honest PREVIEW: the standings shown are clearly labeled
+/// sample data (never presented as the user's real social standing), and the
+/// "You" row shows only the user's OWN real weekly number — or an honest
+/// learning state when the baseline isn't ready. When a real backend
+/// (Supabase) and friends are connected later, the sample rows are replaced
+/// by real ones; nothing here fabricates other people's data as real.
+struct AtriaLeaderboardScreen: View {
+    /// The user's real weekly recovery average (nil while still learning).
+    let myWeeklyRecovery: Int?
+
+    enum Board: String, CaseIterable, Identifiable {
+        case recovery, strain
+        var id: String { rawValue }
+        var title: String { self == .recovery ? "Recovery" : "Strain" }
+        var unit: String { self == .recovery ? "%" : "" }
+    }
+
+    private struct SampleEntry: Identifiable {
+        let id = UUID()
+        let name: String
+        let initial: String
+        let recovery: Int
+        let strain: Double
+        let tint: Color
+    }
+
+    // Clearly-illustrative sample opponents — shown only to demonstrate the
+    // layout, always under an explicit "Sample" label. Not real people.
+    private static let sample: [SampleEntry] = [
+        SampleEntry(name: "Sample · Riya", initial: "R", recovery: 88, strain: 14.2, tint: .green),
+        SampleEntry(name: "Sample · Dev", initial: "D", recovery: 74, strain: 12.8, tint: .mint),
+        SampleEntry(name: "Sample · Aria", initial: "A", recovery: 61, strain: 9.5, tint: .teal),
+    ]
+
+    @State private var board: Board = .recovery
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    previewBanner
+
+                    Picker("Board", selection: $board) {
+                        ForEach(Board.allCases) { Text($0.title).tag($0) }
+                    }
+                    .pickerStyle(.segmented)
+
+                    VStack(spacing: 8) {
+                        ForEach(Array(rankedRows.enumerated()), id: \.offset) { index, row in
+                            row.view(rank: index + 1, board: board)
+                        }
+                    }
+
+                    Text("Sample standings, shown so you can see how the leaderboard will look. Connect an account and invite friends to compete for real — nobody's data is shared until you opt in.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(16)
+            }
+            .navigationTitle("Leaderboard")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }.font(.body.weight(.semibold))
+                }
+            }
+        }
+    }
+
+    private var previewBanner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "trophy.fill")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(.orange)
+                .frame(width: 44, height: 44)
+                .background(.orange.opacity(0.14), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text("Preview")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(.orange)
+                        .padding(.horizontal, 7).padding(.vertical, 2)
+                        .background(.orange.opacity(0.16), in: Capsule())
+                    Text("Not connected yet")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Text("Only your own number below is real.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.orange.opacity(0.07), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private enum Row {
+        case sample(SampleEntry)
+        case you(recovery: Int?)
+
+        @ViewBuilder
+        func view(rank: Int, board: Board) -> some View {
+            switch self {
+            case .sample(let entry):
+                AtriaLeaderboardRow(rank: rank, initial: entry.initial, name: entry.name,
+                                    valueText: board == .recovery ? "\(entry.recovery)%" : String(format: "%.1f", entry.strain),
+                                    tint: entry.tint, isYou: false, sample: true)
+            case .you(let recovery):
+                AtriaLeaderboardRow(rank: rank, initial: "Y", name: "You",
+                                    valueText: board == .recovery ? (recovery.map { "\($0)%" } ?? "Learning") : "Learning",
+                                    tint: .blue, isYou: true, sample: false)
+            }
+        }
+
+        var sortRecovery: Int {
+            switch self {
+            case .sample(let e): return e.recovery
+            case .you(let r): return r ?? -1   // learning sorts last, honestly
+            }
+        }
+    }
+
+    private var rankedRows: [Row] {
+        var rows: [Row] = Self.sample.map(Row.sample)
+        rows.append(.you(recovery: myWeeklyRecovery))
+        return rows.sorted { $0.sortRecovery > $1.sortRecovery }
+    }
+}
+
+private struct AtriaLeaderboardRow: View {
+    let rank: Int
+    let initial: String
+    let name: String
+    let valueText: String
+    let tint: Color
+    let isYou: Bool
+    let sample: Bool
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text("\(rank)")
+                .font(.subheadline.weight(.bold).monospacedDigit())
+                .foregroundStyle(.secondary)
+                .frame(width: 22)
+            Text(initial)
+                .font(.subheadline.weight(.black))
+                .foregroundStyle(.white)
+                .frame(width: 34, height: 34)
+                .background(tint.gradient, in: Circle())
+            VStack(alignment: .leading, spacing: 1) {
+                Text(name)
+                    .font(.subheadline.weight(isYou ? .bold : .semibold))
+                if sample {
+                    Text("Sample")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            Spacer(minLength: 8)
+            Text(valueText)
+                .font(.headline.weight(.bold).monospacedDigit())
+                .foregroundStyle(isYou ? .blue : .primary)
+        }
+        .padding(.horizontal, 12)
+        .frame(minHeight: 52)
+        .background(isYou ? Color.blue.opacity(0.08) : Color(uiColor: .secondarySystemGroupedBackground),
+                    in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(isYou ? Color.blue.opacity(0.4) : .clear, lineWidth: 1)
+        )
+    }
+}

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -3722,8 +3722,8 @@ struct AtriaWeeklyPlanCard: View, Equatable {
             HStack(alignment: .firstTextBaseline) {
                 AtriaPanelSectionHeader(title: "This week", subtitle: "")
                 Spacer(minLength: 8)
-                Text("W\(plan.isoWeek)")
-                    .font(.caption.weight(.bold).monospacedDigit())
+                Text(plan.dateRangeText)
+                    .font(.caption.weight(.bold))
                     .foregroundStyle(.secondary)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -2491,7 +2491,7 @@ struct AtriaOverviewReadinessSection: View, Equatable {
                            value: sleepGlanceValueText,
                            detail: sleepTriRingDetailText,
                            systemImage: sleepGlanceSystemImage,
-                           tint: Metrics.electricSleep,
+                           tint: Metrics.ringAchievementTint(fill: sleepFocusProgress),
                            fill: sleepFocusProgress)
     }
 
@@ -2511,7 +2511,7 @@ struct AtriaOverviewReadinessSection: View, Equatable {
                                   value: hero.strainValue,
                                   detail: targetValueText,
                                   systemImage: AtriaTodayMetric.strain.systemImage,
-                                  tint: Metrics.electricStrain,
+                                  tint: Metrics.ringAchievementTint(fill: metricIsPending(hero.strainValue) ? nil : fill),
                                   fill: metricIsPending(hero.strainValue) ? nil : fill)
     }
 

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -10235,6 +10235,27 @@ private struct AtriaSleepHypnogramCard: View {
                 }
                 .frame(height: 42)
 
+                // Legend so the colored bar is self-explanatory (2026-07-08 UX
+                // audit: it was an unlabeled two-tone bar).
+                let presentStages = SleepStageKind.displayOrder.filter { stage in
+                    night.displayStageSegments.contains { $0.stage == stage }
+                }
+                if !presentStages.isEmpty {
+                    HStack(spacing: 12) {
+                        ForEach(presentStages) { stage in
+                            HStack(spacing: 5) {
+                                Circle()
+                                    .fill(stageTint(stage))
+                                    .frame(width: 8, height: 8)
+                                Text(stage.label)
+                                    .font(.caption2.weight(.semibold))
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                        Spacer(minLength: 0)
+                    }
+                }
+
                 Text("Heart-rate and motion estimate — useful for trend context, not an EEG sleep study.")
                     .font(.caption)
                     .foregroundStyle(.secondary)

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -11222,7 +11222,7 @@ struct AtriaOverviewBehaviorJournalSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             HStack(alignment: .top, spacing: 12) {
-                AtriaPanelSectionHeader(title: "Impacts", subtitle: "Local behavior patterns")
+                AtriaPanelSectionHeader(title: "Impacts", subtitle: "What's affecting you")
 
                 Spacer(minLength: 0)
 
@@ -11296,7 +11296,7 @@ private struct AtriaJournalImpactStrip: View, Equatable {
                     .font(.caption.weight(.bold))
                     .foregroundStyle(.primary)
                 Spacer(minLength: 0)
-                Text(taggedDays > 0 ? "\(taggedDays)d local" : "learning")
+                Text(taggedDays > 0 ? "\(taggedDays)d logged" : "learning")
                     .font(.caption2.weight(.bold).monospacedDigit())
                     .foregroundStyle(.secondary)
                 .padding(.horizontal, 8)
@@ -11875,7 +11875,7 @@ private struct AtriaJournalImpactFocus: View, Equatable {
                     .font(.headline.weight(.bold).monospacedDigit())
                     .lineLimit(1)
                     .minimumScaleFactor(0.72)
-                Text("\(summary.days)d local")
+                Text("\(summary.days)d logged")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -11311,20 +11311,10 @@ private struct AtriaJournalImpactStrip: View, Equatable {
     }
 
     var body: some View {
+        // The inner "Impact" + day-count header was removed (2026-07-08 UX
+        // audit: it duplicated the outer "Impacts" card's title and day chip,
+        // reading as a card-in-card). Contents promote straight up.
         VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .center, spacing: 10) {
-                Label("Impact", systemImage: "waveform.path.ecg")
-                    .font(.caption.weight(.bold))
-                    .foregroundStyle(.primary)
-                Spacer(minLength: 0)
-                Text(taggedDays > 0 ? "\(taggedDays)d logged" : "learning")
-                    .font(.caption2.weight(.bold).monospacedDigit())
-                    .foregroundStyle(.secondary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 5)
-                .background(Color.primary.opacity(0.055), in: Capsule())
-            }
-
             if behaviorImpacts.isEmpty && summaries.isEmpty {
                 HStack(spacing: 8) {
                     Image(systemName: "tag.circle")

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6364,7 +6364,11 @@ private struct AtriaSleepPlanStrip: View, Equatable {
     @AtriaDefault(AtriaWakeAlarmStore.enabledKey) private var wakeAlarmEnabled: Bool = false
     @AtriaDefault(AtriaWakeAlarmStore.modeKey) private var wakeAlarmMode: String = AtriaWakeAlarmPlan.Mode.smartWindow.rawValue
     @AtriaDefault(AtriaWakeAlarmStore.wakeByMinutesKey) private var wakeByMinutes: Int = AtriaWakeAlarmPlan.defaultPlan.wakeByMinutes
+    @AtriaDefault("atria.sleepPlanner.goal") private var plannerGoalRaw: String = AtriaSleepPlannerGoal.peak.rawValue
     @State private var alarmStatusText: String?
+    /// Efficiencies of the user's real confirmed nights, for the planner's
+    /// time-in-bed assumption. Passed in so this card stays store-free.
+    var nightEfficiencies: [Double] = []
 
     static func == (lhs: AtriaSleepPlanStrip, rhs: AtriaSleepPlanStrip) -> Bool {
         lhs.statusText == rhs.statusText
@@ -6899,7 +6903,8 @@ struct AtriaMetricDetailSheet: View {
                                             neededHours: sleepHistory.sleepNeedHours(for: latest,
                                                                                     baseNeedHours: sleepBaseNeedHours,
                                                                                     yesterdayStrain: yesterdayStrainForLatestNight),
-                                            consistencyPercent: sleepHistory.sleepConsistencyPercent)
+                                            consistencyPercent: sleepHistory.sleepConsistencyPercent,
+                                            nightEfficiencies: confirmedNightEfficiencies)
                     sleepNeedLedgerCard(for: latest)
                     sleepDebtTrendCard
                 }
@@ -8073,6 +8078,13 @@ struct AtriaMetricDetailSheet: View {
             .padding(14)
             .atriaInsetCard(tint: Metrics.electricGreen)
         }
+    }
+
+    /// Shaped outside the render block per the perf rule (no compactMap in
+    /// view-builder bodies): real confirmed nights' efficiencies for the
+    /// sleep planner's time-in-bed assumption.
+    private var confirmedNightEfficiencies: [Double] {
+        sleepHistory.nights.filter(\.confirmed).compactMap(\.sleepEfficiency)
     }
 
     /// Overlay candidates for "Edit this chart": the two sibling metrics the
@@ -10185,7 +10197,11 @@ private struct AtriaSleepHypnogramCard: View {
     @AtriaDefault(AtriaWakeAlarmStore.enabledKey) private var wakeAlarmEnabled: Bool = false
     @AtriaDefault(AtriaWakeAlarmStore.modeKey) private var wakeAlarmMode: String = AtriaWakeAlarmPlan.Mode.smartWindow.rawValue
     @AtriaDefault(AtriaWakeAlarmStore.wakeByMinutesKey) private var wakeByMinutes: Int = AtriaWakeAlarmPlan.defaultPlan.wakeByMinutes
+    @AtriaDefault("atria.sleepPlanner.goal") private var plannerGoalRaw: String = AtriaSleepPlannerGoal.peak.rawValue
     @State private var alarmStatusText: String?
+    /// Efficiencies of the user's real confirmed nights, for the planner's
+    /// time-in-bed assumption. Passed in so this card stays store-free.
+    var nightEfficiencies: [Double] = []
 
     private var wakeAlarmPlan: AtriaWakeAlarmPlan {
         AtriaWakeAlarmPlan(mode: AtriaWakeAlarmPlan.Mode(rawValue: wakeAlarmMode) ?? .smartWindow,
@@ -10234,6 +10250,8 @@ private struct AtriaSleepHypnogramCard: View {
 
             wakeAlarmCard
 
+            sleepPlannerCard
+
             if let consistencyPercent {
                 VStack(alignment: .leading, spacing: 6) {
                     ProgressView(value: Double(consistencyPercent), total: 100)
@@ -10246,6 +10264,49 @@ private struct AtriaSleepHypnogramCard: View {
         }
         .padding(14)
         .atriaInsetCard(tint: .cyan)
+    }
+
+    /// Sleep Planner (2026-07-07, WHOOP-research adaptation): pick a goal,
+    /// get an in-bed-by time worked back from the wake alarm using tonight's
+    /// need and the user's own typical efficiency.
+    private var sleepPlannerCard: some View {
+        let goal = AtriaSleepPlannerGoal(rawValue: plannerGoalRaw) ?? .peak
+        let plan = AtriaSleepPlanner.plan(needHours: neededHours,
+                                          goal: goal,
+                                          wakeByMinutes: wakeByMinutes,
+                                          nightEfficiencies: nightEfficiencies)
+        return VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 10) {
+                Image(systemName: "bed.double.circle.fill")
+                    .foregroundStyle(Metrics.electricSleep)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Tonight's plan")
+                        .font(.caption.weight(.bold))
+                    Text("In bed by \(plan.inBedByText) \u{00b7} \(AtriaMetricFormat.sleepHours(plan.targetSleepHours)) asleep")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+
+            Picker("Sleep goal", selection: Binding(
+                get: { AtriaSleepPlannerGoal(rawValue: plannerGoalRaw) ?? .peak },
+                set: { plannerGoalRaw = $0.rawValue })) {
+                ForEach(AtriaSleepPlannerGoal.allCases) { option in
+                    Text(option.title).tag(option)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Text("\(goal.detail) tonight, assuming your \(plan.efficiencyIsDefault ? "typical-population" : "own typical") efficiency (\(Int((plan.assumedEfficiency * 100).rounded()))%)\(plan.efficiencyIsDefault ? " \u{2014} learning yours" : ""). Anchored to your wake-by time above.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(12)
+        .background(Metrics.electricSleep.opacity(0.07), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Tonight's plan. \(goal.title): in bed by \(plan.inBedByText) for \(AtriaMetricFormat.sleepHours(plan.targetSleepHours)) of sleep.")
     }
 
     private var wakeAlarmCard: some View {

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -2913,7 +2913,9 @@ struct AtriaOverviewReadinessSection: View, Equatable {
                                       tint: hrvZone?.tint ?? Metrics.electricHRV,
                                       sparklineValues: dailyMetricSparklines.hrv,
                                       zone: hrvZone,
-                                      calibratingDay: hrvCalibratingDay)
+                                      calibratingDay: hrvCalibratingDay,
+                                      calibratingTotal: PersonalBaseline.trustedMinimumSamples,
+                                      calibratingUnit: "Night")
             }
         case .stress:
             Button {
@@ -2974,7 +2976,9 @@ struct AtriaOverviewReadinessSection: View, Equatable {
                                       tint: restingHeartRateZone?.tint ?? Metrics.electricRHR,
                                       sparklineValues: dailyMetricSparklines.restingHeartRate,
                                       zone: restingHeartRateZone,
-                                      calibratingDay: restingCalibratingDay)
+                                      calibratingDay: restingCalibratingDay,
+                                      calibratingTotal: PersonalBaseline.trustedMinimumSamples,
+                                      calibratingUnit: "Night")
             }
         case .respiratoryRate:
             AtriaGlanceMetricCard(title: "Resp rate",
@@ -3257,12 +3261,15 @@ struct AtriaOverviewReadinessSection: View, Equatable {
         hero.recoveryEstimate.percent == nil ? calibratingDay(sampleCount: max(hrvBaselineSamples, restingBaselineSamples)) : nil
     }
 
+    // HRV/RHR baselines need trustedMinimumSamples (14) nights — so they carry
+    // the RAW recorded-night count (not the capped "day"), and their cards pass
+    // total: 14, unit: "Night" for honest "Night X of 14" progress (2026-07-08).
     private var hrvCalibratingDay: Int? {
-        metricIsPending(hero.hrvValue) ? calibratingDay(sampleCount: hrvBaselineSamples) : nil
+        metricIsPending(hero.hrvValue) ? hrvBaselineSamples : nil
     }
 
     private var restingCalibratingDay: Int? {
-        metricIsPending(hero.restingHeartRateText) ? calibratingDay(sampleCount: restingBaselineSamples) : nil
+        metricIsPending(hero.restingHeartRateText) ? restingBaselineSamples : nil
     }
 
     private var sleepCalibratingDay: Int? {
@@ -4572,6 +4579,8 @@ private struct AtriaGlanceMetricCard: View, Equatable {
     var zone: AtriaMetricZone? = nil
     var accessibilityDetail: String? = nil
     var calibratingDay: Int? = nil
+    var calibratingTotal: Int = 4
+    var calibratingUnit: String = "Day"
     @State private var showingZoneInfo = false
 
     static func == (lhs: AtriaGlanceMetricCard, rhs: AtriaGlanceMetricCard) -> Bool {
@@ -4585,6 +4594,8 @@ private struct AtriaGlanceMetricCard: View, Equatable {
             && lhs.zone == rhs.zone
             && lhs.accessibilityDetail == rhs.accessibilityDetail
             && lhs.calibratingDay == rhs.calibratingDay
+            && lhs.calibratingTotal == rhs.calibratingTotal
+            && lhs.calibratingUnit == rhs.calibratingUnit
     }
 
     static var placeholder: some View {
@@ -4608,7 +4619,7 @@ private struct AtriaGlanceMetricCard: View, Equatable {
     }
 
     private var accessibilityText: String {
-        var parts = [calibratingDay.map { "\(title) calibrating day \(min(max($0, 1), 4)) of 4" } ?? "\(title) \(displayValue)", detail]
+        var parts = [calibratingDay.map { "\(title) calibrating \(calibratingUnit.lowercased()) \(min(max($0, 0), calibratingTotal)) of \(calibratingTotal)" } ?? "\(title) \(displayValue)", detail]
         if let accessibilityDetail,
            !accessibilityDetail.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             parts.append(accessibilityDetail)
@@ -4675,7 +4686,7 @@ private struct AtriaGlanceMetricCard: View, Equatable {
 
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 if let calibratingDay {
-                    AtriaCalibratingLabel(day: calibratingDay, tint: tint)
+                    AtriaCalibratingLabel(day: calibratingDay, total: calibratingTotal, unit: calibratingUnit, tint: tint)
                 } else {
                     Text(displayValue)
                         .font(.system(size: 30, weight: .bold, design: .rounded))
@@ -4724,7 +4735,7 @@ private struct AtriaGlanceMetricCard: View, Equatable {
             .frame(maxWidth: .infinity, alignment: .leading)
 
             if let calibratingDay {
-                AtriaCalibratingLabel(day: calibratingDay, tint: tint)
+                AtriaCalibratingLabel(day: calibratingDay, total: calibratingTotal, unit: calibratingUnit, tint: tint)
                     .layoutPriority(1)
             } else {
                 Text(displayValue)

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -2910,7 +2910,7 @@ struct AtriaOverviewReadinessSection: View, Equatable {
                                       value: metricDisplayValue(hero.hrvValue),
                                       detail: hrvDetailText,
                                       systemImage: metric.systemImage,
-                                      tint: hrvZone?.tint ?? .pink,
+                                      tint: hrvZone?.tint ?? Metrics.electricHRV,
                                       sparklineValues: dailyMetricSparklines.hrv,
                                       zone: hrvZone,
                                       calibratingDay: hrvCalibratingDay)
@@ -2971,7 +2971,7 @@ struct AtriaOverviewReadinessSection: View, Equatable {
                                       value: metricDisplayValue(hero.restingHeartRateText),
                                       detail: "Baseline",
                                       systemImage: metric.systemImage,
-                                      tint: restingHeartRateZone?.tint ?? .pink,
+                                      tint: restingHeartRateZone?.tint ?? Metrics.electricRHR,
                                       sparklineValues: dailyMetricSparklines.restingHeartRate,
                                       zone: restingHeartRateZone,
                                       calibratingDay: restingCalibratingDay)
@@ -2981,7 +2981,7 @@ struct AtriaOverviewReadinessSection: View, Equatable {
                                   value: sleepHistory.latest?.respiratoryRateText ?? "--",
                                   detail: sleepHistory.latest?.respiratoryRate == nil ? "Sleep signal" : "Early",
                                   systemImage: metric.systemImage,
-                                  tint: respiratoryRateZone?.tint ?? (sleepHistory.latest?.respiratoryRate == nil ? .orange : .teal),
+                                  tint: respiratoryRateZone?.tint ?? (sleepHistory.latest?.respiratoryRate == nil ? .orange : Metrics.electricRespiratory),
                                   zone: respiratoryRateZone,
                                   accessibilityDetail: sleepHistory.latest?.respiratoryRate == nil
                                     ? "Respiratory rate is building from sleep-only evidence."
@@ -3039,7 +3039,7 @@ struct AtriaOverviewReadinessSection: View, Equatable {
                                   value: sensorSummary.skinTemperatureDeviation.isReady ? sensorSummary.skinTemperatureDeviation.valueText : "--",
                                   detail: sensorSummary.skinTemperatureDeviation.detailText,
                                   systemImage: metric.systemImage,
-                                  tint: skinTemperatureDeviationZone?.tint ?? (sensorSummary.skinTemperatureDeviation.isReady ? .teal : .orange),
+                                  tint: skinTemperatureDeviationZone?.tint ?? (sensorSummary.skinTemperatureDeviation.isReady ? Metrics.electricRespiratory : .orange),
                                   zone: skinTemperatureDeviationZone,
                                   accessibilityDetail: sensorSummary.skinTemperatureDeviation.isReady
                                     ? "Body temperature early relative signal \(sensorSummary.skinTemperatureDeviation.valueText) delta C from baseline, \(sensorSummary.skinTemperatureDeviation.footnoteText)."

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -11410,6 +11410,10 @@ private struct AtriaJournalImpactGlanceBoard: View, Equatable {
         summaries.first
     }
 
+    private var patternCount: Int {
+        summaries.filter { $0.impactDelta != nil }.count
+    }
+
     private var supportValue: Double {
         min(supportSummaries.reduce(0) { $0 + $1.impactMagnitude } / 12, 1)
     }
@@ -11489,8 +11493,8 @@ private struct AtriaJournalImpactGlanceBoard: View, Equatable {
                            value: taggedDays > 0 ? "\(taggedDays)d" : "0d",
                            systemImage: "calendar.badge.checkmark",
                            tint: .cyan)
-                glanceChip(title: "Links",
-                           value: "\(summaries.filter { $0.impactDelta != nil }.count)",
+                glanceChip(title: "Patterns",
+                           value: patternCount > 0 ? "\(patternCount)" : "—",
                            systemImage: "waveform.path.ecg",
                            tint: .mint)
                 glanceChip(title: "Focus",
@@ -11500,7 +11504,7 @@ private struct AtriaJournalImpactGlanceBoard: View, Equatable {
             }
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Journal impact glance. \(taggedDays) logged days. \(summaries.filter { $0.impactDelta != nil }.count) behavior links. Focus \(focusSummary?.tag.label ?? "tag more"). Watch \(pressureSummaries.count), support \(supportSummaries.count).")
+        .accessibilityLabel("Journal impact glance. \(taggedDays) logged days. \(patternCount) behavior patterns. Focus \(focusSummary?.tag.label ?? "tag more"). Watch \(pressureSummaries.count), support \(supportSummaries.count).")
     }
 
     private func impactLane(title: String,

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -2907,13 +2907,13 @@ struct AtriaOverviewReadinessSection: View, Equatable {
         case .hrv:
             detailButton(.hrv) {
                 AtriaGlanceMetricCard(title: "HRV",
-                                      value: metricDisplayValue(hero.hrvValue),
-                                      detail: hrvDetailText,
+                                      value: hrvCalibratingValue ?? metricDisplayValue(hero.hrvValue),
+                                      detail: hrvCalibratingValue != nil ? calibratingProgressDetail(samples: hrvBaselineSamples) : hrvDetailText,
                                       systemImage: metric.systemImage,
-                                      tint: hrvZone?.tint ?? Metrics.electricHRV,
+                                      tint: (hrvCalibratingValue != nil ? nil : hrvZone)?.tint ?? Metrics.electricHRV,
                                       sparklineValues: dailyMetricSparklines.hrv,
-                                      zone: hrvZone,
-                                      calibratingDay: hrvCalibratingDay,
+                                      zone: hrvCalibratingValue != nil ? nil : hrvZone,
+                                      calibratingDay: hrvCalibratingValue != nil ? nil : hrvCalibratingDay,
                                       calibratingTotal: PersonalBaseline.trustedMinimumSamples,
                                       calibratingUnit: "Night")
             }
@@ -2970,13 +2970,13 @@ struct AtriaOverviewReadinessSection: View, Equatable {
         case .rhr:
             detailButton(.restingHeartRate) {
                 AtriaGlanceMetricCard(title: "RHR",
-                                      value: metricDisplayValue(hero.restingHeartRateText),
-                                      detail: "Baseline",
+                                      value: restingCalibratingValue ?? metricDisplayValue(hero.restingHeartRateText),
+                                      detail: restingCalibratingValue != nil ? calibratingProgressDetail(samples: restingBaselineSamples) : "Baseline",
                                       systemImage: metric.systemImage,
-                                      tint: restingHeartRateZone?.tint ?? Metrics.electricRHR,
+                                      tint: (restingCalibratingValue != nil ? nil : restingHeartRateZone)?.tint ?? Metrics.electricRHR,
                                       sparklineValues: dailyMetricSparklines.restingHeartRate,
-                                      zone: restingHeartRateZone,
-                                      calibratingDay: restingCalibratingDay,
+                                      zone: restingCalibratingValue != nil ? nil : restingHeartRateZone,
+                                      calibratingDay: restingCalibratingValue != nil ? nil : restingCalibratingDay,
                                       calibratingTotal: PersonalBaseline.trustedMinimumSamples,
                                       calibratingUnit: "Night")
             }
@@ -3270,6 +3270,26 @@ struct AtriaOverviewReadinessSection: View, Equatable {
 
     private var restingCalibratingDay: Int? {
         metricIsPending(hero.restingHeartRateText) ? restingBaselineSamples : nil
+    }
+
+    // Partial data during calibration (user 2026-07-08 "start showing something
+    // when we can"): once a baseline value exists, show the real HRV/RHR built so
+    // far — a measured number — instead of hiding it behind the countdown ring.
+    // The detail says it's still calibrating and the zone judgment is suppressed
+    // (there is no trusted baseline to grade the number against yet), so nothing
+    // is fabricated or over-claimed.
+    private var hrvCalibratingValue: String? {
+        guard hrvCalibratingDay != nil, let hrv = baselineTarget.hrvBaseline else { return nil }
+        return "\(hrv)"
+    }
+
+    private var restingCalibratingValue: String? {
+        guard restingCalibratingDay != nil, let rhr = baselineTarget.restingBaseline else { return nil }
+        return "\(rhr)"
+    }
+
+    private func calibratingProgressDetail(samples: Int) -> String {
+        "Calibrating · night \(min(max(samples, 0), PersonalBaseline.trustedMinimumSamples)) of \(PersonalBaseline.trustedMinimumSamples)"
     }
 
     private var sleepCalibratingDay: Int? {

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6747,6 +6747,7 @@ struct AtriaMetricDetailSheet: View {
                                        priorPoints: config.prior,
                                        baselineBand: config.band,
                                        events: expandedChartEvents,
+                                       overlays: expandedChartOverlays,
                                        onDismiss: { showExpandedChart = false })
             }
         }
@@ -8071,6 +8072,27 @@ struct AtriaMetricDetailSheet: View {
             }
             .padding(14)
             .atriaInsetCard(tint: Metrics.electricGreen)
+        }
+    }
+
+    /// Overlay candidates for "Edit this chart": the two sibling metrics the
+    /// inline chart already pairs as scrub companions, in raw daily form.
+    private var expandedChartOverlays: [(title: String, unit: String, tint: Color, points: [AtriaDetailChartPoint])] {
+        switch metric {
+        case .recovery, .strain:
+            return [("HRV", " ms", Metrics.electricHRV, preparedHistory.hrvRaw[range] ?? []),
+                    ("Sleep", " h", Metrics.electricSleep, preparedHistory.sleepRaw[range] ?? [])]
+        case .hrv, .restingHeartRate:
+            return [("Recovery", "%", Metrics.electricGreen, preparedHistory.recoveryRaw[range] ?? []),
+                    ("Sleep", " h", Metrics.electricSleep, preparedHistory.sleepRaw[range] ?? [])]
+        case .sleep:
+            return [("Recovery", "%", Metrics.electricGreen, preparedHistory.recoveryRaw[range] ?? []),
+                    ("Strain", "", Metrics.electricStrain, preparedHistory.strainRaw[range] ?? [])]
+        case .respiratoryRate:
+            return [("HRV", " ms", Metrics.electricHRV, preparedHistory.hrvRaw[range] ?? []),
+                    ("Recovery", "%", Metrics.electricGreen, preparedHistory.recoveryRaw[range] ?? [])]
+        default:
+            return []
         }
     }
 

--- a/Atria/Atria/AtriaResearchBundle.swift
+++ b/Atria/Atria/AtriaResearchBundle.swift
@@ -361,6 +361,55 @@ enum AtriaResearchUploadQueue {
         return nowMin >= startMin || nowMin < endMin
     }
 
+    /// The sharing rule as one pure, testable decision (2026-07-08, user
+    /// request): transmit ONLY while the wearer is asleep OR not actively
+    /// using the phone — and only when opted in, with data to send, and
+    /// without spending a low battery unless charging. `withinSleepWindow`
+    /// comes from `isWithinSleepWindow`; `phoneIdle` from the app's
+    /// foreground / last-interaction state (supplied by the caller). This
+    /// decides only WHEN a transmit attempt runs; an unconfigured endpoint
+    /// still just queues locally, so nothing is fabricated or force-sent.
+    enum TransmitDecision: Equatable {
+        /// reason ∈ { "sleep_window", "phone_idle" }
+        case eligible(reason: String)
+        /// reason ∈ { "sharing_off", "nothing_pending", "low_battery", "phone_in_use" }
+        case hold(reason: String)
+
+        var isEligible: Bool {
+            if case .eligible = self { return true }
+            return false
+        }
+
+        var reason: String {
+            switch self {
+            case .eligible(let reason), .hold(let reason): return reason
+            }
+        }
+    }
+
+    /// Below this phone-battery fraction, hold background sharing unless the
+    /// phone is charging (P4 battery care).
+    static let lowBatteryHoldFraction = 0.20
+
+    static func transmissionEligibility(optedIn: Bool,
+                                        hasPending: Bool,
+                                        withinSleepWindow: Bool,
+                                        phoneIdle: Bool,
+                                        batteryFraction: Double,
+                                        isCharging: Bool) -> TransmitDecision {
+        guard optedIn else { return .hold(reason: "sharing_off") }
+        guard hasPending else { return .hold(reason: "nothing_pending") }
+        // Negative battery = unknown (monitoring off): the battery guard fails
+        // OPEN so an unknown reading never blocks — the sleep/idle guard below
+        // still governs. A known low battery while unplugged holds.
+        if batteryFraction >= 0, batteryFraction < lowBatteryHoldFraction, !isCharging {
+            return .hold(reason: "low_battery")
+        }
+        if withinSleepWindow { return .eligible(reason: "sleep_window") }
+        if phoneIdle { return .eligible(reason: "phone_idle") }
+        return .hold(reason: "phone_in_use")
+    }
+
     private static func dayKey(for date: Date, calendar: Calendar) -> String {
         let components = calendar.dateComponents([.year, .month, .day], from: date)
         return "\(components.year ?? 0)-\(components.month ?? 0)-\(components.day ?? 0)"

--- a/Atria/Atria/AtriaSettingsView.swift
+++ b/Atria/Atria/AtriaSettingsView.swift
@@ -7,6 +7,9 @@ import UniformTypeIdentifiers
 struct AtriaSettingsView: View {
     let profile: AthleteProfile
     let restingBaseline: Int?
+    /// Real weekly recovery average for the leaderboard "You" row (nil while
+    /// still learning). Demo social feature (2026-07-08).
+    var myWeeklyRecovery: Int? = nil
     let strapName: String
     let strapModel: String
     let strapGenerationDetail: String
@@ -35,6 +38,7 @@ struct AtriaSettingsView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var showForgetConfirm = false
+    @State private var showLeaderboard = false
     @State private var draft: AthleteProfile
     @State private var haptics: AtriaHapticAlertSettings
     @State private var nameDraft: String
@@ -101,6 +105,7 @@ struct AtriaSettingsView: View {
 
     init(profile: AthleteProfile,
          restingBaseline: Int?,
+         myWeeklyRecovery: Int? = nil,
          strapName: String = "",
          strapModel: String = "",
          strapGenerationDetail: String = "",
@@ -128,6 +133,7 @@ struct AtriaSettingsView: View {
          researchValidationContent: AnyView? = nil) {
         self.profile = profile
         self.restingBaseline = restingBaseline
+        self.myWeeklyRecovery = myWeeklyRecovery
         self.strapName = strapName
         self.strapModel = strapModel
         self.strapGenerationDetail = strapGenerationDetail
@@ -324,15 +330,42 @@ struct AtriaSettingsView: View {
         Section {
             DisclosureGroup(isExpanded: $expandedSharing) {
                 AtriaResearchSharingSection(buildBundle: buildResearchBundle)
+                leaderboardRow
                 aboutSection
             } label: {
                 settingsGroupLabel("Privacy & Sharing",
-                                   subtitle: "Research sharing, support, app info",
+                                   subtitle: "Research sharing, leaderboard, support",
                                    systemImage: "hand.raised.fill",
                                    tint: .green)
             }
         } footer: {
             Text("Research bundle sharing, app version, and support contact.")
+        }
+    }
+
+    /// Entry to the leaderboard demo (2026-07-08). Self-contained button +
+    /// sheet so it needs no Form-level plumbing.
+    private var leaderboardRow: some View {
+        Button {
+            showLeaderboard = true
+        } label: {
+            HStack {
+                Label("Leaderboard", systemImage: "trophy.fill")
+                Spacer(minLength: 8)
+                Text("Preview")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.orange)
+                    .padding(.horizontal, 7).padding(.vertical, 2)
+                    .background(.orange.opacity(0.16), in: Capsule())
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .font(.subheadline)
+        .foregroundStyle(.primary)
+        .sheet(isPresented: $showLeaderboard) {
+            AtriaLeaderboardScreen(myWeeklyRecovery: myWeeklyRecovery)
         }
     }
 

--- a/Atria/Atria/AtriaSettingsView.swift
+++ b/Atria/Atria/AtriaSettingsView.swift
@@ -777,7 +777,7 @@ struct AtriaSettingsView: View {
                 .atriaCardAction(tint: .orange)
                 } label: {
                     targetGroupHeader(title: "Strain",
-                                  subtitle: "Recovery-scaled target band for day load.",
+                                  subtitle: "Today's strain goal, scaled to how recovered you are.",
                                   systemImage: "figure.run",
                                   tint: .orange)
                 }
@@ -844,7 +844,7 @@ struct AtriaSettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 } label: {
                     targetGroupHeader(title: "Training load",
-                                  subtitle: "ACWR and monotony bands for readiness guidance.",
+                                  subtitle: "Warns when training ramps up too fast or gets too repetitive.",
                                   systemImage: "chart.bar.xaxis",
                                   tint: .orange)
                 }
@@ -874,7 +874,7 @@ struct AtriaSettingsView: View {
                 .atriaCardAction(tint: .green)
                 } label: {
                     targetGroupHeader(title: "Activity",
-                                  subtitle: "Daily strap-step and estimated active calories goals.",
+                                  subtitle: "Your daily step and active-calorie goals.",
                                   systemImage: "figure.walk.motion",
                                   tint: .green)
                 }
@@ -920,7 +920,7 @@ struct AtriaSettingsView: View {
                 .atriaCardAction(tint: .cyan)
                 } label: {
                     targetGroupHeader(title: "Sleep",
-                                  subtitle: "Duration goal and efficiency bands for sleep history.",
+                                  subtitle: "Your nightly sleep goal and how restful your nights were.",
                                   systemImage: "bed.double.fill",
                                   tint: .cyan)
                 }
@@ -966,7 +966,7 @@ struct AtriaSettingsView: View {
                 .atriaCardAction(tint: .pink)
                 } label: {
                     targetGroupHeader(title: "Personal baselines",
-                                  subtitle: "HRV and resting-HR ranges wait for trusted baseline data.",
+                                  subtitle: "Your HRV and resting-heart-rate ranges, set once Atria learns your normal.",
                                   systemImage: "heart.text.square.fill",
                                   tint: .pink)
                 }
@@ -1026,7 +1026,7 @@ struct AtriaSettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 } label: {
                     targetGroupHeader(title: "Sleep-only signals",
-                                  subtitle: "Respiratory, relative skin-temp, and oxygen evidence bands.",
+                                  subtitle: "Breathing rate, skin temperature, and blood-oxygen ranges.",
                                   systemImage: "waveform.path.ecg",
                                   tint: .teal)
                 }
@@ -1061,7 +1061,7 @@ struct AtriaSettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
                 } label: {
                     targetGroupHeader(title: "Fitness age",
-                                  subtitle: "Younger/older delta bands for the local estimate.",
+                                  subtitle: "How much younger or older your fitness looks than your age.",
                                   systemImage: "figure.stand",
                                   tint: .purple)
                 }
@@ -1091,7 +1091,7 @@ struct AtriaSettingsView: View {
                 .atriaCardAction(tint: .blue)
                 } label: {
                     targetGroupHeader(title: "VO2max",
-                                  subtitle: "Trend gain or decline needed for target colors.",
+                                  subtitle: "How much your VO2max must change to shift color.",
                                   systemImage: "lungs.fill",
                                   tint: .blue)
                 }

--- a/Atria/Atria/AtriaSettingsView.swift
+++ b/Atria/Atria/AtriaSettingsView.swift
@@ -39,6 +39,7 @@ struct AtriaSettingsView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var showForgetConfirm = false
     @State private var showLeaderboard = false
+    @State private var showSparring = false
     @State private var draft: AthleteProfile
     @State private var haptics: AtriaHapticAlertSettings
     @State private var nameDraft: String
@@ -331,6 +332,7 @@ struct AtriaSettingsView: View {
             DisclosureGroup(isExpanded: $expandedSharing) {
                 AtriaResearchSharingSection(buildBundle: buildResearchBundle)
                 leaderboardRow
+                sparringRow
                 aboutSection
             } label: {
                 settingsGroupLabel("Privacy & Sharing",
@@ -366,6 +368,31 @@ struct AtriaSettingsView: View {
         .foregroundStyle(.primary)
         .sheet(isPresented: $showLeaderboard) {
             AtriaLeaderboardScreen(myWeeklyRecovery: myWeeklyRecovery)
+        }
+    }
+
+    /// Entry to the sparring demo (2026-07-08), sibling of the leaderboard.
+    private var sparringRow: some View {
+        Button {
+            showSparring = true
+        } label: {
+            HStack {
+                Label("Sparring", systemImage: "figure.fencing")
+                Spacer(minLength: 8)
+                Text("Preview")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(.purple)
+                    .padding(.horizontal, 7).padding(.vertical, 2)
+                    .background(.purple.opacity(0.16), in: Capsule())
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .font(.subheadline)
+        .foregroundStyle(.primary)
+        .sheet(isPresented: $showSparring) {
+            AtriaSparringScreen(myWeeklyRecovery: myWeeklyRecovery)
         }
     }
 

--- a/Atria/Atria/AtriaSharedUIComponents.swift
+++ b/Atria/Atria/AtriaSharedUIComponents.swift
@@ -94,10 +94,16 @@ enum AtriaMetricUnit {
 
 struct AtriaCalibratingLabel: View, Equatable {
     let day: Int
+    /// Honest denominator + noun for the calibration countdown. Defaults keep
+    /// recovery's real "Day X of 4" (a usable preliminary estimate lands ~day 4);
+    /// the 14-night baselines (HRV/RHR) pass total: 14, unit: "Night" so the ring
+    /// never reads complete while the metric is still learning (2026-07-08).
+    var total: Int = 4
+    var unit: String = "Day"
     var tint: Color = .orange
 
     private var clampedDay: Int {
-        min(max(day, 1), 4)
+        min(max(day, 0), total)
     }
 
     var body: some View {
@@ -106,7 +112,7 @@ struct AtriaCalibratingLabel: View, Equatable {
                 Circle()
                     .stroke(tint.opacity(0.25), lineWidth: 3)
                 Circle()
-                    .trim(from: 0, to: Double(clampedDay) / 4)
+                    .trim(from: 0, to: Double(clampedDay) / Double(max(total, 1)))
                     .stroke(tint, style: StrokeStyle(lineWidth: 3, lineCap: .round))
                     .rotationEffect(.degrees(-90))
             }
@@ -115,13 +121,13 @@ struct AtriaCalibratingLabel: View, Equatable {
             VStack(alignment: .leading, spacing: 1) {
                 Text("Calibrating")
                     .font(.caption.weight(.bold))
-                Text("Day \(clampedDay) of 4")
+                Text("\(unit) \(clampedDay) of \(total)")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(.secondary)
             }
         }
         .foregroundStyle(tint)
-        .accessibilityLabel("Calibrating. Day \(clampedDay) of 4.")
+        .accessibilityLabel("Calibrating. \(unit) \(clampedDay) of \(total).")
     }
 }
 
@@ -467,6 +473,8 @@ struct AtriaMetricTile: View, Equatable {
     var zone: AtriaMetricZone? = nil
     var targetMetric: AtriaTodayMetric? = nil
     var calibratingDay: Int? = nil
+    var calibratingTotal: Int = 4
+    var calibratingUnit: String = "Day"
     @State private var showingZoneInfo = false
     @State private var editingTargetMetric: AtriaTodayMetric?
 
@@ -481,6 +489,8 @@ struct AtriaMetricTile: View, Equatable {
             && lhs.zone == rhs.zone
             && lhs.targetMetric == rhs.targetMetric
             && lhs.calibratingDay == rhs.calibratingDay
+            && lhs.calibratingTotal == rhs.calibratingTotal
+            && lhs.calibratingUnit == rhs.calibratingUnit
     }
 
     private var displayValue: String {
@@ -494,7 +504,7 @@ struct AtriaMetricTile: View, Equatable {
     }
 
     private var accessibilityText: String {
-        var parts = [calibratingDay.map { "\(label) calibrating day \(min(max($0, 1), 4)) of 4" } ?? "\(label) \(displayValue)"]
+        var parts = [calibratingDay.map { "\(label) calibrating \(calibratingUnit.lowercased()) \(min(max($0, 0), calibratingTotal)) of \(calibratingTotal)" } ?? "\(label) \(displayValue)"]
         if let unit {
             parts[0] += " \(unit)"
         }
@@ -537,7 +547,7 @@ struct AtriaMetricTile: View, Equatable {
 
             HStack(alignment: .firstTextBaseline, spacing: 5) {
                 if let calibratingDay {
-                    AtriaCalibratingLabel(day: calibratingDay, tint: tint)
+                    AtriaCalibratingLabel(day: calibratingDay, total: calibratingTotal, unit: calibratingUnit, tint: tint)
                 } else {
                     Text(displayValue)
                         .font(.system(size: 29, weight: .bold, design: .rounded))

--- a/Atria/Atria/AtriaSleepPlanner.swift
+++ b/Atria/Atria/AtriaSleepPlanner.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+/// Sleep Planner (2026-07-07, WHOOP-research adaptation): works backwards
+/// from the wake-by time to an "in bed by" recommendation for a chosen
+/// performance goal.
+///
+/// Honesty rules: the sleep-need input is the app's existing ledger math
+/// (never recomputed here), the efficiency assumption comes from the user's
+/// own confirmed nights (population default only while learning, and labeled
+/// as such), and with no wake-by time configured there is no recommendation.
+enum AtriaSleepPlannerGoal: String, Codable, CaseIterable, Identifiable {
+    case peak, perform, getBy
+
+    var id: String { rawValue }
+
+    /// Fraction of tonight's sleep need the goal aims to cover (WHOOP's
+    /// public Peak/Perform/Get By tiers).
+    var needFraction: Double {
+        switch self {
+        case .peak: return 1.0
+        case .perform: return 0.85
+        case .getBy: return 0.70
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .peak: return "Peak"
+        case .perform: return "Perform"
+        case .getBy: return "Get by"
+        }
+    }
+
+    var detail: String {
+        switch self {
+        case .peak: return "100% of need"
+        case .perform: return "85% of need"
+        case .getBy: return "70% of need"
+        }
+    }
+}
+
+struct AtriaSleepPlan: Equatable {
+    let targetSleepHours: Double
+    /// Minutes-of-day (0..<1440) to be in bed by; can wrap past midnight
+    /// into the previous evening.
+    let inBedByMinutes: Int
+    let assumedEfficiency: Double
+    /// True while the efficiency assumption is the population default rather
+    /// than learned from the user's own nights.
+    let efficiencyIsDefault: Bool
+
+    var inBedByText: String {
+        let hour = inBedByMinutes / 60
+        let minute = inBedByMinutes % 60
+        var components = DateComponents()
+        components.hour = hour
+        components.minute = minute
+        let date = Calendar.current.date(from: components) ?? Date()
+        return date.formatted(date: .omitted, time: .shortened)
+    }
+}
+
+enum AtriaSleepPlanner {
+    static let defaultEfficiency = 0.90
+    static let minimumNightsForLearnedEfficiency = 5
+
+    /// Median efficiency across the user's confirmed nights, or the labeled
+    /// population default while fewer than 5 real nights exist.
+    static func assumedEfficiency(nightEfficiencies: [Double]) -> (value: Double, isDefault: Bool) {
+        let usable = nightEfficiencies.filter { $0 > 0.5 && $0 <= 1.0 }.sorted()
+        guard usable.count >= minimumNightsForLearnedEfficiency else {
+            return (defaultEfficiency, true)
+        }
+        let median = usable[usable.count / 2]
+        return (median, false)
+    }
+
+    /// The recommendation. `needHours` is tonight's need from the existing
+    /// ledger; `wakeByMinutes` is the configured wake-by time in minutes of
+    /// day. Time in bed = target sleep / efficiency, clamped to sane bounds.
+    static func plan(needHours: Double,
+                     goal: AtriaSleepPlannerGoal,
+                     wakeByMinutes: Int,
+                     nightEfficiencies: [Double]) -> AtriaSleepPlan {
+        let efficiency = assumedEfficiency(nightEfficiencies: nightEfficiencies)
+        let targetSleep = min(max(needHours * goal.needFraction, 3), 12)
+        let timeInBedMinutes = Int((targetSleep / efficiency.value * 60).rounded())
+        var inBedBy = wakeByMinutes - timeInBedMinutes
+        while inBedBy < 0 { inBedBy += 24 * 60 }
+        return AtriaSleepPlan(targetSleepHours: targetSleep,
+                              inBedByMinutes: inBedBy % (24 * 60),
+                              assumedEfficiency: efficiency.value,
+                              efficiencyIsDefault: efficiency.isDefault)
+    }
+}

--- a/Atria/Atria/AtriaSparringScreen.swift
+++ b/Atria/Atria/AtriaSparringScreen.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+/// Sparring — a 1-v-1 head-to-head challenge (2026-07-08, user-requested P3,
+/// DEMO). Same honesty stance as the leaderboard: this is a clearly-labeled
+/// PREVIEW. Your side shows only your OWN real weekly number (or an honest
+/// learning state); the opponent is an explicitly-labeled sample until a real
+/// friend is connected through a backend later. No one's data is fabricated
+/// as real, and no "winner" is declared while your side is still learning.
+struct AtriaSparringScreen: View {
+    /// The user's real weekly recovery average (nil while still learning).
+    let myWeeklyRecovery: Int?
+
+    // A single clearly-labeled sample opponent for the preview matchup.
+    private let opponentName = "Sample · Riya"
+    private let opponentRecovery = 74
+
+    @Environment(\.dismiss) private var dismiss
+
+    private var hasRealMe: Bool { myWeeklyRecovery != nil }
+    private var iLead: Bool? {
+        guard let mine = myWeeklyRecovery else { return nil }
+        if mine == opponentRecovery { return nil }
+        return mine > opponentRecovery
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    previewBanner
+                    matchupCard
+                    statusLine
+                    Text("Sample matchup, shown so you can see how sparring will look. Challenge a real friend once accounts are connected — your weekly numbers are compared only after you both opt in.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(16)
+            }
+            .navigationTitle("Sparring")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") { dismiss() }.font(.body.weight(.semibold))
+                }
+            }
+        }
+    }
+
+    private var previewBanner: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "figure.fencing")
+                .font(.title3.weight(.bold))
+                .foregroundStyle(.purple)
+                .frame(width: 44, height: 44)
+                .background(.purple.opacity(0.14), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text("Preview")
+                        .font(.caption2.weight(.black))
+                        .foregroundStyle(.purple)
+                        .padding(.horizontal, 7).padding(.vertical, 2)
+                        .background(.purple.opacity(0.16), in: Capsule())
+                    Text("Not connected yet")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+                Text("Only your side is real.")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.purple.opacity(0.07), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private var matchupCard: some View {
+        HStack(alignment: .top, spacing: 8) {
+            fighter(title: "You",
+                    initial: "Y",
+                    valueText: myWeeklyRecovery.map { "\($0)%" } ?? "Learning",
+                    subtitle: "Weekly recovery",
+                    tint: .blue,
+                    leads: iLead == true,
+                    isSample: false)
+            VStack(spacing: 4) {
+                Text("VS")
+                    .font(.caption.weight(.black))
+                    .foregroundStyle(.tertiary)
+            }
+            .frame(maxHeight: .infinity, alignment: .center)
+            fighter(title: opponentName,
+                    initial: "R",
+                    valueText: "\(opponentRecovery)%",
+                    subtitle: "Sample",
+                    tint: .green,
+                    leads: iLead == false,
+                    isSample: true)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func fighter(title: String, initial: String, valueText: String,
+                         subtitle: String, tint: Color, leads: Bool, isSample: Bool) -> some View {
+        VStack(spacing: 8) {
+            ZStack(alignment: .topTrailing) {
+                Text(initial)
+                    .font(.title2.weight(.black))
+                    .foregroundStyle(.white)
+                    .frame(width: 56, height: 56)
+                    .background(tint.gradient, in: Circle())
+                if leads {
+                    Image(systemName: "crown.fill")
+                        .font(.caption2)
+                        .foregroundStyle(.yellow)
+                        .offset(x: 4, y: -4)
+                }
+            }
+            Text(valueText)
+                .font(.title.weight(.bold).monospacedDigit())
+                .foregroundStyle(tint)
+                .contentTransition(.numericText())
+            Text(title)
+                .font(.subheadline.weight(.semibold))
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+            Text(subtitle)
+                .font(.caption2)
+                .foregroundStyle(isSample ? .tertiary : .secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 16)
+        .background(Color(uiColor: .secondarySystemGroupedBackground),
+                    in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var statusLine: some View {
+        switch iLead {
+        case .some(true):
+            sparringStatus(text: "You're ahead this week.", tint: .green, icon: "checkmark.seal.fill")
+        case .some(false):
+            sparringStatus(text: "You're behind — room to push.", tint: .orange, icon: "flame.fill")
+        case .none where hasRealMe:
+            sparringStatus(text: "Dead even this week.", tint: .secondary, icon: "equal.circle.fill")
+        default:
+            sparringStatus(text: "Your side is still learning — a real matchup starts once your baseline is ready.",
+                           tint: .secondary, icon: "hourglass")
+        }
+    }
+
+    private func sparringStatus(text: String, tint: Color, icon: String) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon).foregroundStyle(tint)
+            Text(text).font(.subheadline.weight(.semibold))
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tint.opacity(0.08), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+}

--- a/Atria/Atria/AtriaStressMonitor.swift
+++ b/Atria/Atria/AtriaStressMonitor.swift
@@ -252,6 +252,19 @@ enum AtriaStressMonitor {
 @MainActor
 final class AtriaStressMonitorStore: ObservableObject {
     @Published private(set) var state: AtriaStressState = .noSignal
+    /// Scored readings from this app session (thinned to ~1 per 30s, capped
+    /// at 12h). In-memory only — the history chart shows real gaps for any
+    /// stretch the strap wasn't read, never interpolation.
+    @Published private(set) var history: [StressHistoryPoint] = []
+
+    struct StressHistoryPoint: Identifiable, Equatable {
+        let t: Date
+        /// Continuous activation 0-1 behind the discrete level.
+        let activation: Double
+        let level: AtriaStressLevel
+
+        var id: TimeInterval { t.timeIntervalSinceReferenceDate }
+    }
 
     private var hrBuffer: [(t: Date, bpm: Int)] = []
     private var contactStartedAt: Date?
@@ -268,6 +281,14 @@ final class AtriaStressMonitorStore: ObservableObject {
     private static let activationEMAAlpha = 0.2
     private static let hysteresisMargin = 0.05
     private static let hysteresisHoldTicks = 2
+
+    private func recordHistory(now: Date) {
+        guard case .scored = state.kind, let level = state.level,
+              let activation = smoothedActivation else { return }
+        if let last = history.last, now.timeIntervalSince(last.t) < 30 { return }
+        history.append(StressHistoryPoint(t: now, activation: activation, level: level))
+        history.removeAll { now.timeIntervalSince($0.t) > 12 * 3600 }
+    }
 
     /// Feed one pulse tick in. Safe to call as often as ~every 5s (or on every
     /// HR/RR update); the buffers + EMA absorb the exact cadence.
@@ -377,5 +398,6 @@ final class AtriaStressMonitorStore: ObservableObject {
         if finalState != state {
             state = finalState
         }
+        recordHistory(now: now)
     }
 }

--- a/Atria/Atria/AtriaTodayScreen.swift
+++ b/Atria/Atria/AtriaTodayScreen.swift
@@ -915,9 +915,10 @@ struct AtriaTodayScreen: View {
                                   value: value,
                                   detail: sleepNeedDetailText(performance: performance),
                                   systemImage: "moon.fill",
-                                  // Color-coherence pass (2026-07-05): identity hue always sleep
-                                  // violet -- zone state moved to `stateTint` (the legend dot).
-                                  tint: Metrics.electricSleep,
+                                  // Achievement coloring (2026-07-08, user request): the ring
+                                  // warms to green as sleep fills toward need, so a met goal reads
+                                  // as a win. The legend dot (stateTint) still carries the zone.
+                                  tint: Metrics.ringAchievementTint(fill: performance.map { min(max(Double($0) / 100.0, 0), 1) }),
                                   fill: performance.map { min(max(Double($0) / 100.0, 0), 1) },
                                   stateTint: performance.map { AtriaTriRing.zoneTint(.sleep, percent: Double($0)) },
                                   // A marker at 1.0 (ring closure) exactly when there's a real,
@@ -1030,7 +1031,9 @@ struct AtriaTodayScreen: View {
                                   value: displayHero.strainValue,
                                   detail: target.map { String(format: "of %.1f", $0) } ?? "Strain",
                                   systemImage: "flame.fill",
-                                  tint: Metrics.strainColor(displayHero.strain),
+                                  // Achievement coloring (2026-07-08): green once strain reaches
+                                  // the day's target (color by % of target, not absolute fill).
+                                  tint: Metrics.ringAchievementTint(fill: percentOfTarget.map { $0 / 100 }),
                                   fill: min(max(displayHero.strain / 20.0, 0), 1),
                                   stateTint: percentOfTarget.map { AtriaTriRing.zoneTint(.strain, percent: $0) },
                                   // Honest: no marker unless there's a real target (a real

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -1307,6 +1307,9 @@ private struct AtriaVitalsPulseCardHost: View {
     @AtriaDefault("atria.target.rhr.yellowDelta") private var restingYellowDelta: Int = 7
     @State private var historicalHeartRatePoints: [AtriaHomeModel.HeartRateChartPoint] = []
     @State private var mergeCache = AtriaHeartRateMergeCache()
+    // Debounce the ~1 Hz archive-update firehose so we don't re-parse the tail
+    // on every append (2026-07-08: that was a hang, and it starved the wider load).
+    @State private var lastHistoricalRefresh: Date = .distantPast
     let pulseSparklineStore: AtriaHomeModel.PulseSparklineStore
 
     private var chartPoints: [AtriaHomeModel.HeartRateChartPoint] {
@@ -1342,17 +1345,30 @@ private struct AtriaVitalsPulseCardHost: View {
                 await refreshHistoricalHeartRatePoints()
             }
             .onReceive(NotificationCenter.default.publisher(for: HistoricalArchive.didUpdateNotification)) { _ in
-                Task { await refreshHistoricalHeartRatePoints() }
+                Task { await refreshHistoricalHeartRatePoints(minInterval: 20) }
             }
     }
 
     @MainActor
-    private func refreshHistoricalHeartRatePoints() async {
-        let since = Calendar.current.date(byAdding: .day, value: -2, to: Date())
+    private func refreshHistoricalHeartRatePoints(minInterval: TimeInterval = 0) async {
+        // The archive appends at ~1 Hz; re-parsing the whole tail on every one
+        // was a hang. First load (.task) passes 0 so it never waits; live
+        // updates coalesce to `minInterval` (the live edge is covered by the
+        // sparkline merge, so a slightly stale historical tail is invisible).
+        let now = Date()
+        if minInterval > 0, now.timeIntervalSince(lastHistoricalRefresh) < minInterval { return }
+        lastHistoricalRefresh = now
+        // Load a full 24h span (was capped at ~100 min of raw ~1 Hz samples, so
+        // the "last 12h/24h" windows could never fill — user 2026-07-08), then
+        // downsample off-main to a bounded count. The chart re-thins to ~400 for
+        // display, so ~2500 span-preserving points keep the merge + Equatable
+        // cheap while covering the full window.
+        let since = Calendar.current.date(byAdding: .hour, value: -24, to: now)
         let points = await Task.detached(priority: .utility) {
-            HistoricalArchive.metricHeartRatePoints(since: since).map {
+            let raw = HistoricalArchive.metricHeartRatePoints(since: since, limit: 50_000).map {
                 AtriaHomeModel.HeartRateChartPoint(t: $0.t, bpm: $0.bpm)
             }
+            return AtriaVitalsHeartRateTimeline.downsampledSpan(raw, maxPoints: 2_500)
         }.value
         guard points != historicalHeartRatePoints else { return }
         historicalHeartRatePoints = points
@@ -1465,6 +1481,17 @@ enum AtriaVitalsHeartRateTimeline {
         return (0..<displayBudget).map { index in
             visible[Int((Double(index) * stride).rounded())]
         }
+    }
+
+    /// Uniformly thins a full-resolution series to at most `maxPoints`, always
+    /// keeping the first + last sample so the time SPAN is preserved. Only used
+    /// to bound the merge/compare/display cost — `windowed` re-thins to the
+    /// display budget on top of this (2026-07-08).
+    static func downsampledSpan(_ points: [AtriaHomeModel.HeartRateChartPoint],
+                                maxPoints: Int) -> [AtriaHomeModel.HeartRateChartPoint] {
+        guard maxPoints > 1, points.count > maxPoints else { return points }
+        let stride = Double(points.count - 1) / Double(maxPoints - 1)
+        return (0..<maxPoints).map { points[Int((Double($0) * stride).rounded())] }
     }
 
     /// Maps a pinch to a new window-slider index (2026-07-08, native zoom feel).

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -2928,6 +2928,9 @@ struct AtriaHeartRateExplorer: View {
                             }
                             .onEnded { _ in pinchAnchorIndex = nil }
                     )
+                    // Tactile detent each time zoom crosses a window level, from
+                    // either pinch or slider (2026-07-08, native feel).
+                    .sensoryFeedback(.selection, trigger: currentWindow)
 
                 VStack(spacing: 6) {
                     HStack {

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -1439,6 +1439,18 @@ enum AtriaVitalsHeartRateTimeline {
             visible[Int((Double(index) * stride).rounded())]
         }
     }
+
+    /// Maps a pinch to a new window-slider index (2026-07-08, native zoom feel).
+    /// Pinch OUT (magnification > 1) zooms IN → a shorter window → lower index;
+    /// pinch IN zooms out. log2 so each doubling of the pinch moves ~2 steps.
+    /// Pure + clamped, so it's unit-testable and can't run off the slider.
+    static func windowIndex(fromPinchAnchor anchor: Double,
+                            magnification: Double,
+                            maxIndex: Double,
+                            sensitivity: Double = 2.0) -> Double {
+        let delta = log2(max(magnification, 0.01)) * sensitivity
+        return min(max((anchor - delta).rounded(), 0), maxIndex)
+    }
 }
 
 private struct AtriaVitalsHRVCardHost: View {
@@ -2844,6 +2856,9 @@ struct AtriaHeartRateExplorer: View {
     /// 8 = 24 hr), defaulting to 12 hr. Time-window zoom (user request
     /// 2026-07-07) instead of the old point-count zoom.
     @State private var windowIndex: Double = Double(AtriaVitalsHeartRateTimeline.Window.defaultWindow.rawValue)
+    /// windowIndex captured when a pinch begins, so magnification maps to an
+    /// absolute zoom rather than compounding each frame.
+    @State private var pinchAnchorIndex: Double?
     @State private var series: AtriaHeartRateChartSeries
     @State private var didDebugLoadMetricArchive = false
     @Environment(\.colorScheme) private var colorScheme
@@ -2898,13 +2913,28 @@ struct AtriaHeartRateExplorer: View {
                                         selectedTime: $selectedTime)
                     .frame(maxHeight: .infinity)
                     .frame(minHeight: 320)
+                    // Native pinch-to-zoom over the same window the slider drives
+                    // (2026-07-08). Two-finger, so it never fights the one-finger
+                    // tap/drag inspection.
+                    .gesture(
+                        MagnifyGesture()
+                            .onChanged { value in
+                                let anchor = pinchAnchorIndex ?? windowIndex
+                                if pinchAnchorIndex == nil { pinchAnchorIndex = anchor }
+                                windowIndex = AtriaVitalsHeartRateTimeline.windowIndex(
+                                    fromPinchAnchor: anchor,
+                                    magnification: value.magnification,
+                                    maxIndex: Double(AtriaVitalsHeartRateTimeline.Window.allCases.count - 1))
+                            }
+                            .onEnded { _ in pinchAnchorIndex = nil }
+                    )
 
                 VStack(spacing: 6) {
                     HStack {
                         Text("Showing last \(currentWindow.label)")
                             .font(.subheadline.weight(.bold))
                         Spacer(minLength: 0)
-                        Text("drag to zoom \u{00b7} tap to inspect")
+                        Text("pinch or drag to zoom \u{00b7} tap to inspect")
                             .font(.caption2)
                             .foregroundStyle(.tertiary)
                     }

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -3030,13 +3030,17 @@ struct AtriaHeartRateAxisChart: View, Equatable {
     var body: some View {
         Chart {
             if let buckets {
-                // Smoothed mode: real min-max ceiling/floor band + average.
+                // Smoothed mode: one calm average line with a soft gradient fill
+                // beneath it. The old per-bucket min-max band jumped bucket to
+                // bucket and read as a noisy scribble (user-reported 2026-07-08);
+                // the average already carries the shape, and detail is one zoom
+                // away. Nothing here is synthesized — average is the real mean.
                 ForEach(buckets) { bucket in
                     AreaMark(x: .value("Time", bucket.t),
-                             yStart: .value("Min", bucket.minBPM),
-                             yEnd: .value("Max", bucket.maxBPM))
+                             yStart: .value("Floor", Double(yDomain.lowerBound)),
+                             yEnd: .value("BPM", bucket.average))
                         .interpolationMethod(.monotone)
-                        .foregroundStyle(.red.opacity(0.16))
+                        .foregroundStyle(.red.opacity(0.12).gradient)
                     LineMark(x: .value("Time", bucket.t),
                              y: .value("BPM", bucket.average))
                         .interpolationMethod(.monotone)

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -3879,7 +3879,7 @@ struct AtriaSleepStageSummary: View, Equatable {
 
             AtriaSleepStageHypnogram(segments: night.displayStageSegments,
                                      duration: night.duration)
-                .frame(height: 36)
+                .frame(height: 120)
 
             LazyVGrid(columns: [GridItem(.adaptive(minimum: 112), spacing: 8)], spacing: 8) {
                 ForEach(SleepStageKind.allCases) { stage in
@@ -3995,7 +3995,8 @@ struct AtriaSleepStageBuildingSummary: View, Equatable {
     }
 }
 
-private struct AtriaSleepStageHypnogram: View, Equatable {
+// Internal (was private) so the broader-lane sizing is render-testable.
+struct AtriaSleepStageHypnogram: View, Equatable {
     let segments: [SleepStageSegment]
     let duration: TimeInterval
 
@@ -4025,7 +4026,9 @@ private struct AtriaSleepStageHypnogram: View, Equatable {
 
     private func drawSegments(in context: inout GraphicsContext, size: CGSize) {
         guard duration > 0, !segments.isEmpty else { return }
-        let laneHeight = max(5, min(8, size.height / 5))
+        // Broader lanes (2026-07-08, user request: ~3-4x): scale with the frame
+        // and cap so lanes stay distinct at the taller 120pt hypnogram.
+        let laneHeight = max(12, min(22, size.height / 5.5))
         var elapsed: TimeInterval = 0
         for segment in segments {
             let width = max(1, size.width * segment.duration / duration)

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -1366,9 +1366,49 @@ struct AtriaVitalsLivePulseSection: View {
 }
 
 enum AtriaVitalsHeartRateTimeline {
+    /// Discrete zoom windows for the HR timeline (user request 2026-07-07:
+    /// default to the last 12h, zoom in to the last minute, out to 24h).
+    enum Window: Int, CaseIterable, Identifiable {
+        case min1, min5, min15, min30, hour1, hour3, hour6, hour12, hour24
+        var id: Int { rawValue }
+
+        var seconds: TimeInterval {
+            switch self {
+            case .min1: return 60
+            case .min5: return 5 * 60
+            case .min15: return 15 * 60
+            case .min30: return 30 * 60
+            case .hour1: return 3_600
+            case .hour3: return 3 * 3_600
+            case .hour6: return 6 * 3_600
+            case .hour12: return 12 * 3_600
+            case .hour24: return 24 * 3_600
+            }
+        }
+
+        var label: String {
+            switch self {
+            case .min1: return "1 min"
+            case .min5: return "5 min"
+            case .min15: return "15 min"
+            case .min30: return "30 min"
+            case .hour1: return "1 hr"
+            case .hour3: return "3 hr"
+            case .hour6: return "6 hr"
+            case .hour12: return "12 hr"
+            case .hour24: return "24 hr"
+            }
+        }
+
+        static let defaultWindow = Window.hour12
+    }
+
+    /// Merged live + historical HR at full resolution (capped for safety) so
+    /// the timeline can window + downsample PER zoom level — pre-downsampling
+    /// here would destroy the seconds-resolution the 1-minute zoom needs.
     static func mergedHeartRatePoints(live: [AtriaHomeModel.HeartRateChartPoint],
                                       historical: [AtriaHomeModel.HeartRateChartPoint],
-                                      targetCount: Int = 180) -> [AtriaHomeModel.HeartRateChartPoint] {
+                                      cap: Int = 6_000) -> [AtriaHomeModel.HeartRateChartPoint] {
         guard !historical.isEmpty else { return live }
         var bySecond: [Int: AtriaHomeModel.HeartRateChartPoint] = [:]
         bySecond.reserveCapacity(historical.count + live.count)
@@ -1379,10 +1419,24 @@ enum AtriaVitalsHeartRateTimeline {
             bySecond[Int(point.t.timeIntervalSince1970.rounded())] = point
         }
         let merged = bySecond.values.sorted { $0.t < $1.t }
-        guard merged.count > targetCount else { return merged }
-        let stride = Double(merged.count - 1) / Double(targetCount - 1)
-        return (0..<targetCount).map { index in
-            merged[Int((Double(index) * stride).rounded())]
+        // Keep the newest `cap` if a very long history ever exceeds it.
+        return merged.count > cap ? Array(merged.suffix(cap)) : merged
+    }
+
+    /// Points within `window` of the latest sample, downsampled to
+    /// `displayBudget` for a smooth chart. Anchored to the latest sample (not
+    /// wall-clock) so "last 12h" always shows the most recent 12h of real
+    /// data rather than blank time when the strap has been off.
+    static func windowed(_ points: [AtriaHomeModel.HeartRateChartPoint],
+                         window: Window,
+                         displayBudget: Int = 200) -> [AtriaHomeModel.HeartRateChartPoint] {
+        guard let latest = points.last?.t else { return [] }
+        let cutoff = latest.addingTimeInterval(-window.seconds)
+        let visible = points.filter { $0.t >= cutoff }
+        guard visible.count > displayBudget else { return visible }
+        let stride = Double(visible.count - 1) / Double(displayBudget - 1)
+        return (0..<displayBudget).map { index in
+            visible[Int((Double(index) * stride).rounded())]
         }
     }
 }
@@ -2631,7 +2685,7 @@ private struct AtriaPulseCard: View, Equatable {
                 pulseStatTiles
             }
 
-            AtriaHeartRateTimelineCard(points: chartPoints,
+            AtriaHeartRateTimelineCard(points: AtriaVitalsHeartRateTimeline.windowed(chartPoints, window: .hour12),
                                        onOpen: { showHeartRateExplorer = true })
         }
         .padding(18)
@@ -2786,11 +2840,18 @@ struct AtriaHeartRateExplorer: View {
     let debugLoadsMetricArchive: Bool
     let onDismiss: () -> Void
     @State private var selectedTime: Date?
-    @State private var zoom: Double = 1
+    /// Slider position over AtriaVitalsHeartRateTimeline.Window (0 = 1 min …
+    /// 8 = 24 hr), defaulting to 12 hr. Time-window zoom (user request
+    /// 2026-07-07) instead of the old point-count zoom.
+    @State private var windowIndex: Double = Double(AtriaVitalsHeartRateTimeline.Window.defaultWindow.rawValue)
     @State private var series: AtriaHeartRateChartSeries
     @State private var didDebugLoadMetricArchive = false
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+
+    private var currentWindow: AtriaVitalsHeartRateTimeline.Window {
+        AtriaVitalsHeartRateTimeline.Window(rawValue: Int(windowIndex.rounded())) ?? .defaultWindow
+    }
 
     init(points: [AtriaHomeModel.HeartRateChartPoint],
          currentBPM: Int,
@@ -2800,7 +2861,9 @@ struct AtriaHeartRateExplorer: View {
         self.currentBPM = currentBPM
         self.debugLoadsMetricArchive = debugLoadsMetricArchive
         self.onDismiss = onDismiss
-        _series = State(initialValue: AtriaHeartRateChartSeries.make(points: points, zoom: 1))
+        _series = State(initialValue: AtriaHeartRateChartSeries.make(
+            points: AtriaVitalsHeartRateTimeline.windowed(points, window: .defaultWindow, displayBudget: 400),
+            zoom: 1))
     }
 
     private var selectedPoint: AtriaHomeModel.HeartRateChartPoint? {
@@ -2836,10 +2899,22 @@ struct AtriaHeartRateExplorer: View {
                     .frame(maxHeight: .infinity)
                     .frame(minHeight: 320)
 
-                HStack(spacing: 12) {
-                    Image(systemName: "minus.magnifyingglass")
-                    Slider(value: $zoom, in: 1...6, step: 1)
-                    Image(systemName: "plus.magnifyingglass")
+                VStack(spacing: 6) {
+                    HStack {
+                        Text("Showing last \(currentWindow.label)")
+                            .font(.subheadline.weight(.bold))
+                        Spacer(minLength: 0)
+                        Text("drag to zoom \u{00b7} tap to inspect")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
+                    HStack(spacing: 10) {
+                        Text("1 min").font(.caption2).foregroundStyle(.tertiary)
+                        Slider(value: $windowIndex,
+                               in: 0...Double(AtriaVitalsHeartRateTimeline.Window.allCases.count - 1),
+                               step: 1)
+                        Text("24 hr").font(.caption2).foregroundStyle(.tertiary)
+                    }
                 }
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
@@ -2858,11 +2933,15 @@ struct AtriaHeartRateExplorer: View {
                     .accessibilityLabel("Done")
                 }
             }
-            .onChange(of: zoom) { _, newValue in
-                series = AtriaHeartRateChartSeries.make(points: points, zoom: newValue)
+            .onChange(of: windowIndex) { _, _ in
+                series = AtriaHeartRateChartSeries.make(
+                    points: AtriaVitalsHeartRateTimeline.windowed(points, window: currentWindow, displayBudget: 400),
+                    zoom: 1)
             }
             .onChange(of: points) { _, newValue in
-                series = AtriaHeartRateChartSeries.make(points: newValue, zoom: zoom)
+                series = AtriaHeartRateChartSeries.make(
+                    points: AtriaVitalsHeartRateTimeline.windowed(newValue, window: currentWindow, displayBudget: 400),
+                    zoom: 1)
             }
             .onAppear {
                 Task { await loadMetricArchiveForDebugProofIfNeeded() }
@@ -2883,7 +2962,9 @@ struct AtriaHeartRateExplorer: View {
         }.value
         AtriaDebugLog("ATRIADBG hist1_timeline_explorer_archive status=loaded points=%d", loaded.count)
         guard !loaded.isEmpty else { return }
-        series = AtriaHeartRateChartSeries.make(points: loaded, zoom: zoom)
+        series = AtriaHeartRateChartSeries.make(
+            points: AtriaVitalsHeartRateTimeline.windowed(loaded, window: currentWindow, displayBudget: 400),
+            zoom: 1)
     }
 }
 

--- a/Atria/Atria/AtriaVitalsCollectionSections.swift
+++ b/Atria/Atria/AtriaVitalsCollectionSections.swift
@@ -1281,6 +1281,23 @@ private struct AtriaDutyCycleToggleCard: View {
     }
 }
 
+/// Memoizes the live+historical HR merge (2026-07-08 perf audit): the merge is
+/// an O(n) dict build + O(n log n) sort over up to 6000 points and was rebuilt
+/// on every `body` eval (~1-2x/sec on the pulse tick). A reference cache keyed
+/// on the cheap array identities recomputes ONLY when the HR data changes —
+/// live is append-only and historical is replaced wholesale, so (count, last
+/// timestamp) fully captures a change.
+private final class AtriaHeartRateMergeCache {
+    struct Key: Equatable {
+        let historicalCount: Int
+        let historicalLast: Date?
+        let liveCount: Int
+        let liveLast: Date?
+    }
+    var key: Key?
+    var value: [AtriaHomeModel.HeartRateChartPoint] = []
+}
+
 private struct AtriaVitalsPulseCardHost: View {
     @ObservedObject var liveStore: AtriaHomeModel.CoreLiveStore
     @ObservedObject var pulseStore: AtriaHomeModel.PulseLiveStore
@@ -1289,11 +1306,21 @@ private struct AtriaVitalsPulseCardHost: View {
     @AtriaDefault("atria.target.rhr.greenDelta") private var restingGreenDelta: Int = 3
     @AtriaDefault("atria.target.rhr.yellowDelta") private var restingYellowDelta: Int = 7
     @State private var historicalHeartRatePoints: [AtriaHomeModel.HeartRateChartPoint] = []
+    @State private var mergeCache = AtriaHeartRateMergeCache()
     let pulseSparklineStore: AtriaHomeModel.PulseSparklineStore
 
     private var chartPoints: [AtriaHomeModel.HeartRateChartPoint] {
-        AtriaVitalsHeartRateTimeline.mergedHeartRatePoints(live: pulseSparklineStore.state.chartPoints,
-                                                           historical: historicalHeartRatePoints)
+        let live = pulseSparklineStore.state.chartPoints
+        let key = AtriaHeartRateMergeCache.Key(historicalCount: historicalHeartRatePoints.count,
+                                               historicalLast: historicalHeartRatePoints.last?.t,
+                                               liveCount: live.count,
+                                               liveLast: live.last?.t)
+        if mergeCache.key == key { return mergeCache.value }
+        let merged = AtriaVitalsHeartRateTimeline.mergedHeartRatePoints(live: live,
+                                                                        historical: historicalHeartRatePoints)
+        mergeCache.key = key
+        mergeCache.value = merged
+        return merged
     }
 
     var body: some View {

--- a/Atria/Atria/AtriaWeeklyPlan.swift
+++ b/Atria/Atria/AtriaWeeklyPlan.swift
@@ -30,6 +30,20 @@ struct WeeklyPlan: Codable, Equatable {
     let generatedAt: Date
     let targets: [WeeklyPlanTarget]
 
+    /// Plain-language week label (e.g. "Jul 7–13") for the surface, instead of
+    /// the ISO week number "W28" — nobody thinks in week-of-year (2026-07-08
+    /// UX audit: jargon on the surface).
+    var dateRangeText: String {
+        let calendar = WeeklyPlanCalendar.iso
+        guard let interval = calendar.dateInterval(of: .weekOfYear, for: generatedAt) else { return "" }
+        let end = calendar.date(byAdding: .day, value: 6, to: interval.start) ?? interval.start
+        let startText = interval.start.formatted(.dateTime.month(.abbreviated).day())
+        let endText = calendar.isDate(interval.start, equalTo: end, toGranularity: .month)
+            ? end.formatted(.dateTime.day())
+            : end.formatted(.dateTime.month(.abbreviated).day())
+        return "\(startText)–\(endText)"
+    }
+
     init(rollups: [DailyRollupStoreEntry],
          now: Date = Date(),
          calendar: Calendar = WeeklyPlanCalendar.iso) {

--- a/Atria/Atria/AtriaWorkoutOnset.swift
+++ b/Atria/Atria/AtriaWorkoutOnset.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Finds where a workout's REAL effort begins, so the auto-detected start can
+/// be trimmed off the getting-ready/walking-out lead-in (user-reported
+/// 2026-07-07: workout detected 8:40 PM but started 9:06 PM).
+///
+/// Pure + deterministic. It never fabricates a boundary: it only reports the
+/// timestamp of the first sample that begins a sustained run AT OR ABOVE the
+/// elevated threshold (using the same continuity/micro-gap-reconnect logic as
+/// workout detection). Callers apply strict guards and fail closed to the
+/// untrimmed start when no honest onset exists.
+enum AtriaWorkoutOnset {
+    static func firstSustainedElevatedOnset(samples: [(t: Date, bpm: Int)],
+                                            rest: Int,
+                                            maxHR: Int,
+                                            thresholdFraction: Double = 0.50,
+                                            minimumOnsetSeconds: TimeInterval = 90,
+                                            continuityGapLimit: TimeInterval = 15,
+                                            microGapReseedCadence: TimeInterval = 3,
+                                            microGapReseedJumpBPM: Int = 25) -> Date? {
+        guard samples.count > 1 else { return nil }
+        let reserve = max(0, maxHR - rest)
+        guard reserve > 0 else { return nil }
+        let threshold = rest + Int((Double(reserve) * min(max(thresholdFraction, 0), 1)).rounded())
+
+        var boutStart: Date?
+        var boutSeconds: TimeInterval = 0
+        for index in 1..<samples.count {
+            let previous = samples[index - 1]
+            let current = samples[index]
+            let dt = max(0, current.t.timeIntervalSince(previous.t))
+            // A hard stream gap breaks the bout (matches sustainedEvidence).
+            if dt > continuityGapLimit {
+                boutStart = nil
+                boutSeconds = 0
+                continue
+            }
+            // A micro-gap reconnect paired with a big bpm jump is an unverified
+            // blip — it cannot seed or extend an elevated bout.
+            let microGapReconnect = dt > microGapReseedCadence
+            let unverifiedBlip = microGapReconnect && abs(current.bpm - previous.bpm) >= microGapReseedJumpBPM
+            let elevated = current.bpm >= threshold && !unverifiedBlip
+            if elevated {
+                if boutStart == nil {
+                    boutStart = current.t
+                    boutSeconds = 0
+                } else {
+                    boutSeconds += dt
+                }
+                if boutSeconds >= minimumOnsetSeconds, let start = boutStart {
+                    return start
+                }
+            } else {
+                boutStart = nil
+                boutSeconds = 0
+            }
+        }
+        return nil
+    }
+}

--- a/Atria/Atria/AtriaWorkoutOnset.swift
+++ b/Atria/Atria/AtriaWorkoutOnset.swift
@@ -57,4 +57,36 @@ enum AtriaWorkoutOnset {
         }
         return nil
     }
+
+    /// HR stats over a workout window's real samples. Pure so the
+    /// honesty-critical averages (which must match a trimmed start/duration)
+    /// are unit-testable. `windowSeconds` is the displayed span for coverage.
+    static func windowStats(samples: [(t: Date, bpm: Int)],
+                            windowSeconds: TimeInterval,
+                            continuityGapLimit: TimeInterval = 15)
+        -> (avgHR: Int, peakHR: Int, p95HR: Int, p99HR: Int,
+            observedDuration: TimeInterval, streamCoveragePercent: Int, samples: Int)? {
+        guard samples.count > 1 else { return nil }
+        let bpms = samples.map(\.bpm)
+        let sorted = bpms.sorted()
+        func percentile(_ fraction: Double) -> Int {
+            let index = min(sorted.count - 1, max(0, Int((Double(sorted.count - 1) * fraction).rounded())))
+            return sorted[index]
+        }
+        var observed: TimeInterval = 0
+        for index in 1..<samples.count {
+            let dt = samples[index].t.timeIntervalSince(samples[index - 1].t)
+            if dt <= continuityGapLimit { observed += dt }
+        }
+        let coverage = windowSeconds > 0
+            ? min(100, max(0, Int((observed / windowSeconds * 100).rounded())))
+            : 0
+        return (bpms.reduce(0, +) / bpms.count,
+                bpms.max() ?? 0,
+                percentile(0.95),
+                percentile(0.99),
+                observed,
+                coverage,
+                samples.count)
+    }
 }

--- a/Atria/Atria/AtriaWorkoutPromptEvaluator.swift
+++ b/Atria/Atria/AtriaWorkoutPromptEvaluator.swift
@@ -23,22 +23,35 @@ enum AtriaWorkoutPromptEvaluator {
                          now: Date = Date()) -> Result {
         let referenceDate = samples.last?.t ?? now
         let sustainedStart = referenceDate.addingTimeInterval(-TimeInterval(minimumSustainedSamples))
-        let elevatedSamples = samples.filter {
-            $0.t >= sustainedStart && $0.bpm - restingHeartRate >= minimumBPMOverRest
-        }.count
+        let zoneStart = referenceDate.addingTimeInterval(-zoneLookbackSeconds)
+
+        // Perf (2026-07-07, device-reported lag): this runs on the main thread
+        // every ~750ms while connected on the home tab, and `samples` is the
+        // whole live session — ~80k after a 13.8h wear day. Only the trailing
+        // ~8 min ever matter (samples are time-ascending, as `referenceDate =
+        // samples.last?.t` already assumes), so walk the tail and stop at the
+        // earliest cutoff instead of two full-array scans. Counts are
+        // order-independent, so this is byte-identical to the old filters;
+        // if a tail were ever out of order it could only under-count -> a
+        // missed prompt, never a false workout (fail closed).
+        let earliestCutoff = min(sustainedStart, zoneStart)
+        var elevatedSamples = 0
+        var zoneSamples = 0
+        for sample in samples.reversed() {
+            if sample.t < earliestCutoff { break }
+            if sample.t >= sustainedStart, sample.bpm - restingHeartRate >= minimumBPMOverRest {
+                elevatedSamples += 1
+            }
+            if sample.t >= zoneStart,
+               let zone = Metrics.heartRateZone(bpm: sample.bpm,
+                                                rest: restingHeartRate,
+                                                max: maxHeartRate),
+               zone.index >= zoneMinimumIndex {
+                zoneSamples += 1
+            }
+        }
         let currentElevated = currentHeartRate - restingHeartRate >= minimumBPMOverRest
         let sustainedPath = elevatedSamples >= minimumSustainedSamples && currentElevated
-
-        let zoneStart = referenceDate.addingTimeInterval(-zoneLookbackSeconds)
-        let zoneSamples = samples.filter { sample in
-            guard sample.t >= zoneStart,
-                  let zone = Metrics.heartRateZone(bpm: sample.bpm,
-                                                   rest: restingHeartRate,
-                                                   max: maxHeartRate) else {
-                return false
-            }
-            return zone.index >= zoneMinimumIndex
-        }.count
         let zonePath = zoneSamples >= zoneMinimumSamples
 
         return Result(shouldPrompt: sustainedPath || zonePath,

--- a/Atria/Atria/LocalNotificationScheduler.swift
+++ b/Atria/Atria/LocalNotificationScheduler.swift
@@ -826,11 +826,13 @@ enum LocalNotificationScheduler {
 
         let rest = store.baseline.restingInt ?? ble.restingHR ?? store.sessions.first?.restingStable ?? 60
         let savedTRIMP = store.todayTRIMP(rest: rest, max: store.profile.maxHR)
-        let liveTRIMP = ble.session.first.map { first in
-            Metrics.trimp(ble.session.map { (t: $0.t.timeIntervalSince(first.t), bpm: $0.bpm) },
-                          rest: rest,
-                          max: store.profile.maxHR)
-        } ?? 0
+        // Perf (2026-07-08 audit): reuse the incremental accumulator (integrates
+        // only NEW samples) instead of re-mapping + re-integrating the whole
+        // live session (up to ~80k samples) on every notification evaluation.
+        // Same TRIMP math (consecutive dt is identical); both are @MainActor.
+        let liveTRIMP = WidgetSnapshotPublisher.incrementalLiveTRIMP(samples: ble.session,
+                                                                     rest: rest,
+                                                                     max: store.profile.maxHR)
         let strain = Metrics.strain(fromTRIMP: savedTRIMP + liveTRIMP)
         let guide = Coach.guide(recovery: recovery.percent, strain: strain)
         let strainDecision: NotificationDecision

--- a/Atria/Atria/LocalNotificationScheduler.swift
+++ b/Atria/Atria/LocalNotificationScheduler.swift
@@ -195,8 +195,10 @@ enum LocalNotificationScheduler {
             AtriaDebugLog("ATRIADBG notification_schedule status=skipped_toggle kind=evening_checkin")
             return
         }
+        // 14-day (not 7-day) re-engage window — see scheduleMorningJournalCheckIn:
+        // the reminder must outlast a typical lapse to rebuild the journal habit.
         guard let lastJournalActivity,
-              now.timeIntervalSince(lastJournalActivity) <= 7 * 24 * 60 * 60 else {
+              now.timeIntervalSince(lastJournalActivity) <= 14 * 24 * 60 * 60 else {
             AtriaDebugLog("ATRIADBG notification_skip kind=evening_checkin reason=journal_inactive")
             return
         }
@@ -281,8 +283,11 @@ enum LocalNotificationScheduler {
             AtriaDebugLog("ATRIADBG notification_schedule status=skipped_toggle kind=morning_checkin")
             return
         }
+        // 14-day (not 7-day) re-engage window: a journal reminder must survive a
+        // typical lapse to help rebuild the habit — a 7-day gate drops it exactly
+        // when the user has stopped and most needs the nudge (user 2026-07-08 #1/#7).
         guard let lastJournalActivity,
-              now.timeIntervalSince(lastJournalActivity) <= 7 * 24 * 60 * 60 else {
+              now.timeIntervalSince(lastJournalActivity) <= 14 * 24 * 60 * 60 else {
             AtriaDebugLog("ATRIADBG notification_skip kind=morning_checkin reason=journal_inactive")
             return
         }

--- a/Atria/Atria/LocalNotificationScheduler.swift
+++ b/Atria/Atria/LocalNotificationScheduler.swift
@@ -33,6 +33,7 @@ enum LocalNotificationScheduler {
         static let morningSummaryPrefix = "atria.morningSummary."
         static let weeklyReportPrefix = "atria.weeklyReport."
         static let eveningJournalPrefix = "atria.eveningJournal."
+        static let morningJournalPrefix = "atria.morningJournal."
         static let healthDeviation = "atria.health.deviation"
         static let recovery = "atria.recovery.ready"
         static let strain = "atria.strain.target"
@@ -139,6 +140,9 @@ enum LocalNotificationScheduler {
 
             let identifier = Identifier.morningSummaryPrefix + day
             center.removePendingNotificationRequests(withIdentifiers: [identifier])
+            // The rich summary carries the journal nudge itself, so cancel the
+            // plain pre-scheduled morning check-in for this day — no double nudge.
+            center.removePendingNotificationRequests(withIdentifiers: [Identifier.morningJournalPrefix + day])
             // Adaptive timing (docs/24 §14.2): deliver no earlier than YOUR
             // learned wake + 15 min; metrics landing later fire immediately.
             let windowEnd = UserDefaults.standard.integer(forKey: AtriaBLEManager.DutyCycleDefaults.sleepWindowEndMin)
@@ -247,6 +251,93 @@ enum LocalNotificationScheduler {
                 UserDefaults.standard.set(targetDay, forKey: scheduledDayKey)
             } catch {
                 AtriaDebugLog("ATRIADBG notification_error kind=evening_checkin error=%@",
+                              String(describing: error))
+            }
+        }
+    }
+
+    /// Minutes-past-midnight for the morning journal nudge: learned wake + 15
+    /// (the duty-cycle window end is median wake + 1 h, so `windowEnd - 60` is
+    /// wake), or 08:00 until the window is learned. Pure + wraps across midnight,
+    /// so it's unit-testable.
+    nonisolated static func morningNudgeMinutes(windowEnd: Int) -> Int {
+        windowEnd > 0 ? ((((windowEnd + 1440 - 60) % 1440) + 15) % 1440) : 8 * 60
+    }
+
+    /// Morning journal check-in — the peer of scheduleEveningJournalCheckIn.
+    /// The rich morning summary (scheduleMorningSummary) only fires when a full
+    /// recovery+HRV+sleep metric is ready, and it folds the journal nudge into
+    /// itself. On a strict-gate morning where last night's sleep isn't confirmed,
+    /// that summary is skipped and the user got NO wake nudge at all (user
+    /// 2026-07-08). This pre-schedules a plain, honest journal nudge for the
+    /// learned wake time so the ask survives whether or not the night was
+    /// confirmed — it carries NO fabricated metrics. scheduleMorningSummary
+    /// cancels this one for the day when the rich summary does fire, so they
+    /// never both land.
+    static func scheduleMorningJournalCheckIn(lastJournalActivity: Date?,
+                                              now: Date = Date(),
+                                              calendar: Calendar = .current) {
+        guard AtriaNotificationSettings.load().allows(kind: "morning_summary") else {
+            AtriaDebugLog("ATRIADBG notification_schedule status=skipped_toggle kind=morning_checkin")
+            return
+        }
+        guard let lastJournalActivity,
+              now.timeIntervalSince(lastJournalActivity) <= 7 * 24 * 60 * 60 else {
+            AtriaDebugLog("ATRIADBG notification_skip kind=morning_checkin reason=journal_inactive")
+            return
+        }
+        // Scene foregrounds fire this many times a day; schedule at most once per
+        // target day.
+        let scheduledDayKey = "atria.notification.morningJournal.scheduledDay"
+
+        // Deliver at YOUR learned wake + 15 min — the same anchor the rich summary
+        // uses (the duty-cycle window end is median wake + 1 h). Falls back to
+        // 08:00 until the window is learned from confirmed sleeps.
+        let windowEnd = UserDefaults.standard.integer(forKey: AtriaBLEManager.DutyCycleDefaults.sleepWindowEndMin)
+        let nudgeMinutes = morningNudgeMinutes(windowEnd: windowEnd)
+        var target = calendar.date(bySettingHour: nudgeMinutes / 60,
+                                   minute: nudgeMinutes % 60,
+                                   second: 0,
+                                   of: now) ?? now
+        if target.timeIntervalSince(now) < 60 {
+            target = calendar.date(byAdding: .day, value: 1, to: target) ?? target
+        }
+        let delay = target.timeIntervalSince(now)
+        let targetDay = localDayIdentifier(for: target, calendar: calendar)
+        guard UserDefaults.standard.string(forKey: scheduledDayKey) != targetDay else { return }
+
+        configureDeliveryLogger()
+        Task {
+            let center = UNUserNotificationCenter.current()
+            _ = await requestProvisionalAuthorization(center: center)
+            let settings = await notificationSettings(center: center)
+            let status = statusName(settings.authorizationStatus)
+            guard settings.authorizationStatus == .authorized ||
+                    settings.authorizationStatus == .provisional ||
+                    settings.authorizationStatus == .ephemeral else {
+                AtriaDebugLog("ATRIADBG notification_schedule status=blocked reason=authorization_%@ kind=morning_checkin",
+                              status)
+                return
+            }
+
+            let identifier = Identifier.morningJournalPrefix + targetDay
+            center.removePendingNotificationRequests(withIdentifiers: [identifier])
+            let decision = NotificationDecision(kind: "morning_summary",
+                                                identifier: identifier,
+                                                title: "Morning check-in",
+                                                body: "A minute now sharpens today's recovery insights.",
+                                                reason: "morning_journal_checkin",
+                                                shouldSchedule: true,
+                                                delay: delay,
+                                                categoryIdentifier: "atria.morningSummary",
+                                                userInfo: ["deepLink": "atria://journal"])
+            do {
+                try await add(decision: decision, center: center)
+                UserDefaults.standard.set(targetDay, forKey: scheduledDayKey)
+                AtriaDebugLog("ATRIADBG notification_schedule status=scheduled kind=morning_checkin target_day=%@ delay_s=%.0f",
+                              targetDay, delay)
+            } catch {
+                AtriaDebugLog("ATRIADBG notification_error kind=morning_checkin error=%@",
                               String(describing: error))
             }
         }

--- a/Atria/Atria/Metrics.swift
+++ b/Atria/Atria/Metrics.swift
@@ -180,6 +180,19 @@ enum Metrics {
     /// Electric sleep indigo — sleep owns purple so it stays distinct from strain.
     static let electricSleep = adaptive(dark: (0.51, 0.35, 1.0), light: (0.39, 0.25, 0.78))
 
+    /// "Close your rings" achievement coloring (2026-07-08, user request): a
+    /// progress ring warms from orange → yellow → green as it fills, landing on
+    /// green the moment it reaches its target so a completed day reads as a
+    /// win. `fill` is progress toward the metric's OWN target (>= 1.0 = reached);
+    /// nil = not computed yet (neutral). Recovery keeps its own %-band green,
+    /// which uses the same green, so an all-good day shows three green rings.
+    static func ringAchievementTint(fill: Double?) -> Color {
+        guard let fill else { return .secondary }
+        if fill >= 0.999 { return .green }
+        if fill >= 0.6 { return .yellow }
+        return .orange
+    }
+
     // Secondary-vital identity hues. Each metric owns ONE hue (the "one hue per
     // metric" rule) drawn from the design-handoff palette, and — like the bands
     // above — is deepened on light so a tinted chip/number stays legible on

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -8121,7 +8121,10 @@ final class SessionStore: ObservableObject {
     /// dropped. Identity/readiness are computed from the untrimmed window by
     /// the caller; this only sharpens the displayed start.
     private func sustainedWorkoutOnsetStart(start: Date, end: Date, rest: Int, maxHR: Int) -> Date? {
-        let overlapping = canonicalSessions().filter { session in
+        // includeActiveJournal: true to match the save gate (2026-07-08 audit):
+        // confirmWorkoutWindow admits a workout on active-journal (live) HR, so
+        // the onset/stats/strain must see the SAME samples, not exclude them.
+        let overlapping = canonicalSessions(includeActiveJournal: true).filter { session in
             session.end > start && session.start < end && !session.points.isEmpty
         }
         guard !overlapping.isEmpty else { return nil }
@@ -8148,7 +8151,8 @@ final class SessionStore: ObservableObject {
     private func workoutWindowHRStats(start: Date, end: Date)
         -> (avgHR: Int, peakHR: Int, p95HR: Int, p99HR: Int,
             observedDuration: TimeInterval, streamCoveragePercent: Int, samples: Int)? {
-        let overlapping = canonicalSessions().filter { session in
+        // includeActiveJournal: true — same sample set as the save gate (audit #9).
+        let overlapping = canonicalSessions(includeActiveJournal: true).filter { session in
             session.end > start && session.start < end && !session.points.isEmpty
         }
         guard !overlapping.isEmpty else { return nil }
@@ -8174,7 +8178,8 @@ final class SessionStore: ObservableObject {
                                                         activeEnergyKilocalories: Double?,
                                                         activeEnergyConfidence: String?,
                                                         zoneSeconds: [String: TimeInterval]?) {
-        let overlapping = canonicalSessions().filter { session in
+        // includeActiveJournal: true — same sample set as the save gate (audit #9).
+        let overlapping = canonicalSessions(includeActiveJournal: true).filter { session in
             session.end > start && session.start < end && !session.points.isEmpty
         }
         guard !overlapping.isEmpty else { return (nil, nil, nil, nil) }

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -11777,16 +11777,23 @@ final class SessionStore: ObservableObject {
         let respiratoryRates = recent.compactMap {
             $0.sleepRespiratoryRate(rest: rest, maxHR: maxHR)
         }
-        let latestSleep = sleepHistorySnapshot.latest
-        let recoveries = recent.compactMap {
+        // Per-day sleep (2026-07-08 consistency audit): each session's recovery
+        // must use ITS OWN night's sleep, not the single latest night applied to
+        // every session in the window — which diverged from the per-day history
+        // recovery (makeHistoryTrendSummaries resolves per-day the same way).
+        let nightsByDay = Dictionary(sleepHistorySnapshot.nights.map {
+            (Calendar.current.startOfDay(for: $0.day), $0)
+        }, uniquingKeysWith: { first, _ in first })
+        let recoveries = recent.compactMap { session -> Int? in
+            let night = nightsByDay[Calendar.current.startOfDay(for: session.start)]
             let recovery = Metrics.recoveryV2(hrvSnapshot: nil,
-                                              fallbackRMSSD: $0.localRMSSD,
-                                              restingNow: $0.restingStable,
+                                              fallbackRMSSD: session.localRMSSD,
+                                              restingNow: session.restingStable,
                                               baseline: baseline,
-                                              hrvReferenceValidated: $0.hrvReferenceValidated == true,
-                                              sleepEfficiency: latestSleep?.sleepEfficiency,
-                                              sleepDurationHours: latestSleep?.durationHours,
-                                              respiratoryRate: $0.sleepRespiratoryRate(rest: rest, maxHR: maxHR),
+                                              hrvReferenceValidated: session.hrvReferenceValidated == true,
+                                              sleepEfficiency: night?.sleepEfficiency,
+                                              sleepDurationHours: night?.durationHours,
+                                              respiratoryRate: session.sleepRespiratoryRate(rest: rest, maxHR: maxHR),
                                               respiratoryBaseline: sleepHistorySnapshot.respiratoryBaselineStats)
             return recovery.percent
         }

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -7723,16 +7723,19 @@ final class SessionStore: ObservableObject {
                                                  detail: "peak_over_rest=\(summary.bestPeakHR - rest), observed \(Int(summary.bestObservedDuration))s, coverage \(summary.bestStreamCoveragePercent)%",
                                                  windowStart: displayStart,
                                                  windowEnd: end))
+        // Trimmed-window HR stats so the review card's avg/coverage match its
+        // shown (trimmed) start + duration (honesty rule); nil when no trim.
+        let reviewStats = displayStart != start ? workoutWindowHRStats(start: displayStart, end: end) : nil
         return WorkoutReviewCandidate(id: id,
                                       start: displayStart,
                                       end: end,
                                       kind: summary.readySessions > 0 ? .workout : .activityCandidate,
                                       confidence: reviewConfidence,
                                       duration: end.timeIntervalSince(displayStart),
-                                      avgHR: summary.bestAvgHR,
-                                      peakHR: summary.bestPeakHR,
-                                      streamCoveragePercent: summary.bestStreamCoveragePercent,
-                                      observedDuration: summary.bestObservedDuration,
+                                      avgHR: reviewStats?.avgHR ?? summary.bestAvgHR,
+                                      peakHR: reviewStats?.peakHR ?? summary.bestPeakHR,
+                                      streamCoveragePercent: reviewStats?.streamCoveragePercent ?? summary.bestStreamCoveragePercent,
+                                      observedDuration: reviewStats?.observedDuration ?? summary.bestObservedDuration,
                                       droppedGapSeconds: summary.bestDroppedGapSeconds,
                                       maxSampleGap: summary.bestMaxSampleGap,
                                       gapCount: summary.bestGapCount,
@@ -7851,6 +7854,10 @@ final class SessionStore: ObservableObject {
         // was already decided from the untrimmed window; only start + strain
         // tighten. Fails closed to bestStart when there's no honest onset.
         let displayStart = sustainedWorkoutOnsetStart(start: bestStart, end: bestEnd, rest: rest, maxHR: maxHR) ?? bestStart
+        // When the start was trimmed, recompute the DISPLAYED HR stats over the
+        // trimmed window so avg/coverage/observed/percentiles match the shown
+        // start+duration+strain (honesty rule). nil = no trim -> summary values.
+        let trimmedStats = displayStart != bestStart ? workoutWindowHRStats(start: displayStart, end: bestEnd) : nil
         let enriched = confirmedWorkoutMetrics(start: displayStart,
                                                end: bestEnd,
                                                rest: rest,
@@ -7864,14 +7871,14 @@ final class SessionStore: ObservableObject {
                                              source: summary.bestSource,
                                              confidence: confidence,
                                              sessions: summary.bestChunkCount,
-                                             samples: summary.bestSamples,
-                                             avgHR: summary.bestAvgHR,
-                                             peakHR: summary.bestPeakHR,
-                                             p95HR: summary.bestP95HR,
-                                             p99HR: summary.bestP99HR,
+                                             samples: trimmedStats?.samples ?? summary.bestSamples,
+                                             avgHR: trimmedStats?.avgHR ?? summary.bestAvgHR,
+                                             peakHR: trimmedStats?.peakHR ?? summary.bestPeakHR,
+                                             p95HR: trimmedStats?.p95HR ?? summary.bestP95HR,
+                                             p99HR: trimmedStats?.p99HR ?? summary.bestP99HR,
                                              thresholdHR: summary.bestThresholdHR,
-                                             streamCoveragePercent: summary.bestStreamCoveragePercent,
-                                             observedDuration: summary.bestObservedDuration,
+                                             streamCoveragePercent: trimmedStats?.streamCoveragePercent ?? summary.bestStreamCoveragePercent,
+                                             observedDuration: trimmedStats?.observedDuration ?? summary.bestObservedDuration,
                                              reason: summary.bestReason,
                                              strain: enriched.strain,
                                              activeEnergyKilocalories: enriched.activeEnergyKilocalories,
@@ -8110,6 +8117,32 @@ final class SessionStore: ObservableObject {
               end.timeIntervalSince(onset) >= 5 * 60
         else { return nil }
         return onset
+    }
+
+    /// Displayed HR stats recomputed over an (onset-trimmed) window from the
+    /// REAL samples, so avgHR/coverage/observed/percentiles match the trimmed
+    /// start + duration + strain instead of the old untrimmed summary values
+    /// (honesty rule: a 39-min effort must not show an average diluted by the
+    /// trimmed-off getting-ready lead-in). nil if the window has no samples.
+    private func workoutWindowHRStats(start: Date, end: Date)
+        -> (avgHR: Int, peakHR: Int, p95HR: Int, p99HR: Int,
+            observedDuration: TimeInterval, streamCoveragePercent: Int, samples: Int)? {
+        let overlapping = canonicalSessions().filter { session in
+            session.end > start && session.start < end && !session.points.isEmpty
+        }
+        guard !overlapping.isEmpty else { return nil }
+        var points: [(t: Date, bpm: Int)] = []
+        for session in overlapping {
+            for point in session.points where point.bpm > 0 {
+                let t = session.start.addingTimeInterval(max(0, point.t))
+                if t >= start, t <= end { points.append((t, point.bpm)) }
+            }
+        }
+        guard points.count > 1 else { return nil }
+        points.sort { $0.t < $1.t }
+        return AtriaWorkoutOnset.windowStats(samples: points,
+                                             windowSeconds: end.timeIntervalSince(start),
+                                             continuityGapLimit: SavedSession.workoutContinuityGapLimit)
     }
 
     private func confirmedWorkoutMetrics(start: Date,

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -4934,13 +4934,14 @@ final class SessionStore: ObservableObject {
             return cachedHomeSavedAggregate
         }
 
-        var savedTodayTRIMP = 0.0
-        var hasSavedToday = false
-        for session in sessions {
-            guard calendar.isDateInToday(session.start) else { break }
-            hasSavedToday = true
-            savedTodayTRIMP += session.trimp(rest: rest, max: maxHR)
-        }
+        // Deduped, today-filtered (2026-07-08 consistency audit): the hero
+        // ring's day strain must sum the SAME session set as the widget's
+        // todayTRIMP — canonicalSessions() (deduped), not the raw `sessions`
+        // array with a break, which double-counted BLE-reconnect fragments and
+        // assumed the today rows were strictly sorted contiguously at the front.
+        let todaySessions = canonicalSessions().filter { calendar.isDateInToday($0.start) }
+        let savedTodayTRIMP = todaySessions.reduce(0) { $0 + $1.trimp(rest: rest, max: maxHR) }
+        let hasSavedToday = !todaySessions.isEmpty
 
         let aggregate = HomeSavedAggregate(rest: rest,
                                            maxHR: maxHR,

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -16039,7 +16039,10 @@ private struct HistoryActivityRhythmCard: View {
     }
 
     private var sleepContextCount: Int {
-        rollups.reduce(0) { $0 + $1.sleepReady + $1.sleepCandidates }
+        // max, not sum: a ready night is also a candidate. Since sleepReady
+        // became HR-only-eligible (2026-07-08) the two are no longer disjoint,
+        // so summing double-counted every auto-confirmed night.
+        rollups.reduce(0) { $0 + max($1.sleepReady, $1.sleepCandidates) }
     }
 
     var body: some View {
@@ -16279,12 +16282,12 @@ private struct DailyRollupRow: View {
             if rollup.restCandidates > 0 {
                 rollupChip(title: "Rest", value: "\(rollup.restCandidates)", tint: .cyan)
             }
-            if rollup.sleepReady + rollup.sleepCandidates > 0 {
-                rollupChip(title: "Sleep", value: "\(rollup.sleepReady + rollup.sleepCandidates)", tint: .blue)
+            if max(rollup.sleepReady, rollup.sleepCandidates) > 0 {
+                rollupChip(title: "Sleep", value: "\(max(rollup.sleepReady, rollup.sleepCandidates))", tint: .blue)
             }
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("Saved \(formatMinutes(rollup.duration)), \(rollup.confirmedWorkouts) confirmed workouts, \(rollup.activityCandidates) activity reviews, \(rollup.sleepReady + rollup.sleepCandidates) sleep items.")
+        .accessibilityLabel("Saved \(formatMinutes(rollup.duration)), \(rollup.confirmedWorkouts) confirmed workouts, \(rollup.activityCandidates) activity reviews, \(max(rollup.sleepReady, rollup.sleepCandidates)) sleep items.")
     }
 
     private func rollupChip(title: String, value: String, tint: Color) -> some View {

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -4216,10 +4216,14 @@ final class SessionStore: ObservableObject {
         return (mean, sqrt(variance), values.count)
     }
 
-    private nonisolated static func sleepEfficiency(duration: TimeInterval?, span: TimeInterval?) -> Double? {
-        guard let duration, duration > 0 else { return nil }
-        let denominator = max(span ?? duration, duration)
-        guard denominator > 0 else { return nil }
+    // Internal (was private) so the honesty rule below is unit-testable.
+    nonisolated static func sleepEfficiency(duration: TimeInterval?, span: TimeInterval?) -> Double? {
+        // Honesty (2026-07-08 audit): when the in-bed span is unknown we do NOT
+        // know efficiency — return nil so recovery skips the sleep signal,
+        // instead of `max(span ?? duration, duration)` which made an unknown
+        // span read as a fabricated 100% and inflated the recovery score.
+        guard let duration, duration > 0, let span, span > 0 else { return nil }
+        let denominator = max(span, duration)
         return min(max(duration / denominator, 0), 1)
     }
 

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -11815,7 +11815,28 @@ final class SessionStore: ObservableObject {
                                       restingTrend: restingTrend14)
     }
 
+    private var cachedBiologicalAge: (summary: BiologicalAgeSummary, computedAt: Date)?
+
+    /// Fitness age moves slowly (WHOOP recomputes "WHOOP Age"/VO2max on a WEEKLY
+    /// timer), so recompute it at most weekly instead of on every profile-metrics
+    /// publish + daily-rollup refresh. The expensive canonicalSessions + per-
+    /// session timeInZone scan (which only runs once baselines are trusted) was on
+    /// the main-thread hot path — user 2026-07-08: "biological age could be weekly/
+    /// biweekly … lesser load on the app all the time." Only the READY value is
+    /// cached; while calibrating it returns .building cheaply on every call.
     func biologicalAgeSummary(vo2MaxEstimate: VO2MaxEstimateSummary) -> BiologicalAgeSummary {
+        if let cached = cachedBiologicalAge,
+           Date().timeIntervalSince(cached.computedAt) < 7 * 24 * 60 * 60 {
+            return cached.summary
+        }
+        let summary = computeBiologicalAgeSummary(vo2MaxEstimate: vo2MaxEstimate)
+        if summary.isReady {
+            cachedBiologicalAge = (summary, Date())
+        }
+        return summary
+    }
+
+    private func computeBiologicalAgeSummary(vo2MaxEstimate: VO2MaxEstimateSummary) -> BiologicalAgeSummary {
         let chronologicalAge = profile.age
         var blockers: [String] = []
         if vo2MaxEstimate.value == nil { blockers.append("vo2max_learning") }

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -3980,7 +3980,14 @@ final class SessionStore: ObservableObject {
             let dayDetections = detectionsByDay[day] ?? []
             let sleepDetections = dayDetections.filter { $0.kind == .sleepCandidate }
             let aggregateSleep = aggregateSleeps[day]
-            let aggregateSleepReady = (aggregateSleep?.motionEvidenceValidated == true && aggregateSleep?.confidence != .low) ? 1 : 0
+            // Sleep-ready aligned with the app's own auto-confirm gate
+            // (2026-07-08, device-reported "Sleep --" after 3 nights): the old
+            // flag required motionEvidenceValidated, structurally impossible on
+            // an accelerometer-less chest strap, so overnight sleep this app
+            // already confirms from HR alone was dropped from the readiness
+            // counter. isStrongAutoConfirmableSleepCandidate keeps the motion
+            // path preferred and still fails naps/marginal nights closed.
+            let aggregateSleepReady = (aggregateSleep.map(Self.isStrongAutoConfirmableSleepCandidate) == true) ? 1 : 0
             let singleSessionSleepDuration = sleepDetections.reduce(0) { $0 + $1.duration }
             let sleepStart = aggregateSleep?.start ?? sleepDetections.map(\.start).min()
             let sleepEnd = aggregateSleep?.end ?? sleepDetections.map(\.end).max()
@@ -10637,7 +10644,14 @@ final class SessionStore: ObservableObject {
             let restCandidates = detections.filter { $0.kind == .restCandidate }.count
             let singleSessionSleepCandidates = detections.filter { $0.kind == .sleepCandidate }.count
             let aggregateSleep = aggregateSleeps[day]
-            let aggregateSleepReady = (aggregateSleep?.motionEvidenceValidated == true && aggregateSleep?.confidence != .low) ? 1 : 0
+            // Sleep-ready aligned with the app's own auto-confirm gate
+            // (2026-07-08, device-reported "Sleep --" after 3 nights): the old
+            // flag required motionEvidenceValidated, structurally impossible on
+            // an accelerometer-less chest strap, so overnight sleep this app
+            // already confirms from HR alone was dropped from the readiness
+            // counter. isStrongAutoConfirmableSleepCandidate keeps the motion
+            // path preferred and still fails naps/marginal nights closed.
+            let aggregateSleepReady = (aggregateSleep.map(Self.isStrongAutoConfirmableSleepCandidate) == true) ? 1 : 0
             let sleepCandidates = max(singleSessionSleepCandidates, aggregateSleep == nil ? 0 : 1)
             let singleSessionSleepDuration = detections
                 .filter { $0.kind == .sleepCandidate }

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -4310,6 +4310,22 @@ final class SessionStore: ObservableObject {
             }
     }
 
+    /// Whether the scored night's recovery inputs differ between the preserved
+    /// frozen daily row and a fresh recompute — i.e. a sleep confirm / EXTEND /
+    /// adjust re-derived today's overnight readiness, so the preserved recovery
+    /// would go stale (2026-07-08). Compares ONLY the frozen overnight inputs to
+    /// recovery (the sleep window + HRV/RHR/respiratory), never live/drifting
+    /// values, so intra-day drift can't trigger a re-mint.
+    nonisolated static func dailyRecoveryInputsChanged(frozen: SavedDailyMetric,
+                                                       fresh: SavedDailyMetric) -> Bool {
+        frozen.sleepEnd != fresh.sleepEnd
+            || frozen.sleepDuration != fresh.sleepDuration
+            || frozen.sleepSpan != fresh.sleepSpan
+            || frozen.hrv != fresh.hrv
+            || frozen.restingHR != fresh.restingHR
+            || frozen.respiratoryRate != fresh.respiratoryRate
+    }
+
     nonisolated static func mergeDailyMetricHistory(existing: [SavedDailyMetric],
                                                             computed: [SavedDailyMetric],
                                                             sessions: [SavedSession],
@@ -4327,26 +4343,48 @@ final class SessionStore: ObservableObject {
 
         if let frozenToday = existing.first(where: { calendar.isDate($0.day, inSameDayAs: today) }) {
             // Once today's morning reading settles, preserve that frozen readiness
-            // snapshot (HRV/RHR/sleep) for the rest of the day instead of recomputing
-            // on refresh. Strain is a cumulative, all-day total (not an overnight
-            // readiness reading) and must keep accruing as later sessions land, or the
-            // displayed number silently stops climbing after the first refresh of the
-            // day — recompute it fresh each time from the same-day computed rollup.
-            let freshStrainToday = computed.first { calendar.isDate($0.day, inSameDayAs: today) }?.strain
-            merged[today] = SavedDailyMetric(day: frozenToday.day,
-                                             recoveryPercent: frozenToday.recoveryPercent,
-                                             recoveryConfidence: frozenToday.recoveryConfidence,
-                                             hrv: frozenToday.hrv,
-                                             restingHR: frozenToday.restingHR,
-                                             respiratoryRate: frozenToday.respiratoryRate,
-                                             sleepDuration: frozenToday.sleepDuration,
-                                             sleepSpan: frozenToday.sleepSpan,
-                                             sleepStart: frozenToday.sleepStart,
-                                             sleepEnd: frozenToday.sleepEnd,
-                                             sleepSource: frozenToday.sleepSource,
-                                             sleepStageSegments: frozenToday.sleepStageSegments,
-                                             sleepConsistencyPercent: frozenToday.sleepConsistencyPercent,
-                                             strain: freshStrainToday ?? frozenToday.strain)
+            // snapshot (HRV/RHR/sleep → recovery) for the rest of the day instead of
+            // recomputing on refresh. Strain is a cumulative, all-day total (not an
+            // overnight readiness reading) and must keep accruing as later sessions
+            // land, or the displayed number silently stops climbing after the first
+            // refresh of the day — recompute it fresh each time from the same-day
+            // computed rollup.
+            let freshToday = computed.first { calendar.isDate($0.day, inSameDayAs: today) }
+            // BUT if the scored NIGHT itself changed (a sleep confirm / EXTEND / adjust
+            // re-derives today's overnight inputs — e.g. the 2026-07-08 sleep-expand
+            // path moving the night's end), the preserved recovery would go STALE.
+            // Re-mint the frozen readiness from the CURRENT night via the same stable
+            // minter so the persisted recovery + trend point never outlive the night
+            // they describe.
+            let base: SavedDailyMetric
+            if let freshToday,
+               dailyRecoveryInputsChanged(frozen: frozenToday, fresh: freshToday),
+               let reminted = makeMorningFrozenDailyMetric(for: today,
+                                                           computed: computed,
+                                                           sessions: sessions,
+                                                           sleep: sleep,
+                                                           baseline: baseline,
+                                                           maxHR: maxHR,
+                                                           now: now,
+                                                           calendar: calendar) {
+                base = reminted
+            } else {
+                base = frozenToday
+            }
+            merged[today] = SavedDailyMetric(day: base.day,
+                                             recoveryPercent: base.recoveryPercent,
+                                             recoveryConfidence: base.recoveryConfidence,
+                                             hrv: base.hrv,
+                                             restingHR: base.restingHR,
+                                             respiratoryRate: base.respiratoryRate,
+                                             sleepDuration: base.sleepDuration,
+                                             sleepSpan: base.sleepSpan,
+                                             sleepStart: base.sleepStart,
+                                             sleepEnd: base.sleepEnd,
+                                             sleepSource: base.sleepSource,
+                                             sleepStageSegments: base.sleepStageSegments,
+                                             sleepConsistencyPercent: base.sleepConsistencyPercent,
+                                             strain: freshToday?.strain ?? base.strain)
         } else if let settledMorning = makeMorningFrozenDailyMetric(for: today,
                                                                     computed: computed,
                                                                     sessions: sessions,

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -7680,7 +7680,11 @@ final class SessionStore: ObservableObject {
             return nil
         }
 
+        // Identity stays on the untrimmed window so a dismissed/confirmed
+        // effort never resurfaces under a new id; only the displayed start is
+        // sharpened to the real onset (getting-ready trimmed). Fails closed.
         let id = confirmedWorkoutID(start: start, end: end, source: summary.bestSource)
+        let displayStart = sustainedWorkoutOnsetStart(start: start, end: end, rest: rest, maxHR: maxHR) ?? start
         let alreadyConfirmed = cachedConfirmedWorkouts.contains { workout in
             if workout.id == id { return true }
             // Two efforts can't overlap in time, so a candidate sharing a
@@ -7717,14 +7721,14 @@ final class SessionStore: ObservableObject {
                       summary.moderateStrengthReviewCandidate ? 1 : 0)
         DetectionEventLog.append(DetectionEvent(kind: "workoutDetected",
                                                  detail: "peak_over_rest=\(summary.bestPeakHR - rest), observed \(Int(summary.bestObservedDuration))s, coverage \(summary.bestStreamCoveragePercent)%",
-                                                 windowStart: start,
+                                                 windowStart: displayStart,
                                                  windowEnd: end))
         return WorkoutReviewCandidate(id: id,
-                                      start: start,
+                                      start: displayStart,
                                       end: end,
                                       kind: summary.readySessions > 0 ? .workout : .activityCandidate,
                                       confidence: reviewConfidence,
-                                      duration: end.timeIntervalSince(start),
+                                      duration: end.timeIntervalSince(displayStart),
                                       avgHR: summary.bestAvgHR,
                                       peakHR: summary.bestPeakHR,
                                       streamCoveragePercent: summary.bestStreamCoveragePercent,
@@ -7841,14 +7845,20 @@ final class SessionStore: ObservableObject {
         }
         let confidence = summary.readySessions > 0 ? "auto_ready_user_confirmed" :
             (summary.nearMiss ? "user_confirmed_near_miss" : "user_confirmed_candidate")
-        let enriched = confirmedWorkoutMetrics(start: bestStart,
+        // Sharpen the displayed start to the real effort onset (getting-ready
+        // trimmed off). `id` above stays on the untrimmed bestStart so identity
+        // is stable (no dismissed/confirmed workout resurfaces), and readiness
+        // was already decided from the untrimmed window; only start + strain
+        // tighten. Fails closed to bestStart when there's no honest onset.
+        let displayStart = sustainedWorkoutOnsetStart(start: bestStart, end: bestEnd, rest: rest, maxHR: maxHR) ?? bestStart
+        let enriched = confirmedWorkoutMetrics(start: displayStart,
                                                end: bestEnd,
                                                rest: rest,
                                                maxHR: maxHR,
                                                excludedIntervals: [])
         let confirmed = UserConfirmedWorkout(id: id,
                                              createdAt: Date(),
-                                             start: bestStart,
+                                             start: displayStart,
                                              end: bestEnd,
                                              label: summary.bestLabel,
                                              source: summary.bestSource,
@@ -8072,6 +8082,34 @@ final class SessionStore: ObservableObject {
                                                  windowStart: confirmed.start,
                                                  windowEnd: confirmed.end))
         return confirmed
+    }
+
+    /// The trimmed workout start (2026-07-07, user-reported early boundary):
+    /// the first sustained-elevated onset within [start, end], from the REAL
+    /// overlapping HR samples — so the getting-ready/walking-out lead-in is
+    /// not swept into the workout. Fails closed to nil (caller keeps the
+    /// untrimmed start) unless the trim removes >= 60s AND still leaves >= 5
+    /// min of workout, so a ready workout stays ready and no real effort is
+    /// dropped. Identity/readiness are computed from the untrimmed window by
+    /// the caller; this only sharpens the displayed start.
+    private func sustainedWorkoutOnsetStart(start: Date, end: Date, rest: Int, maxHR: Int) -> Date? {
+        let overlapping = canonicalSessions().filter { session in
+            session.end > start && session.start < end && !session.points.isEmpty
+        }
+        guard !overlapping.isEmpty else { return nil }
+        var samples: [(t: Date, bpm: Int)] = []
+        for session in overlapping {
+            for point in session.points where point.bpm > 0 {
+                let t = session.start.addingTimeInterval(max(0, point.t))
+                if t >= start, t <= end { samples.append((t, point.bpm)) }
+            }
+        }
+        samples.sort { $0.t < $1.t }
+        guard let onset = AtriaWorkoutOnset.firstSustainedElevatedOnset(samples: samples, rest: rest, maxHR: maxHR),
+              onset > start.addingTimeInterval(60),
+              end.timeIntervalSince(onset) >= 5 * 60
+        else { return nil }
+        return onset
     }
 
     private func confirmedWorkoutMetrics(start: Date,

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -4046,6 +4046,22 @@ final class SessionStore: ObservableObject {
         .sorted { $0.day > $1.day }
     }
 
+    /// Per-DAY strain values (day-summed TRIMP → score), NOT per-session
+    /// scores. score() saturates, so averaging per-session scores under-reports
+    /// a day's strain ~2x versus the day-summed strain every other surface
+    /// shows — trend charts must use this (2026-07-08 calc-consistency audit).
+    nonisolated static func perDayStrains(_ sessions: [SavedSession],
+                                          rest: Int,
+                                          maxHR: Int,
+                                          calendar: Calendar = .current) -> [Double] {
+        var trimpByDay: [Date: Double] = [:]
+        for session in sessions {
+            let day = calendar.startOfDay(for: session.start)
+            trimpByDay[day, default: 0] += session.trimp(rest: rest, max: maxHR)
+        }
+        return trimpByDay.values.map { Metrics.strain(fromTRIMP: $0) }
+    }
+
     private nonisolated static func makeHistoryTrendSummaries(sessions: [SavedSession],
                                                               rollups: [DailyRollup],
                                                               baseline: PersonalBaseline,
@@ -4064,7 +4080,7 @@ final class SessionStore: ObservableObject {
                 let evidence = session.baselineLearningEvidence(rest: rest, maxHR: maxHR)
                 return evidence.accepted ? evidence.value : nil
             }
-            let strains = recent.map { Metrics.strain(fromTRIMP: $0.trimp(rest: rest, max: maxHR)) }
+            let strains = Self.perDayStrains(recent, rest: rest, maxHR: maxHR)
             let hrvs = recent.compactMap(\.localRMSSD).filter { $0 > 0 }
             let respiratoryRates = recent.compactMap {
                 $0.sleepRespiratoryRate(rest: rest, maxHR: maxHR)
@@ -11610,7 +11626,7 @@ final class SessionStore: ObservableObject {
                 let evidence = session.baselineLearningEvidence(rest: rest, maxHR: maxHR)
                 return evidence.accepted ? evidence.value : nil
             }
-            let strains = recent.map { Metrics.strain(fromTRIMP: $0.trimp(rest: rest, max: maxHR)) }
+            let strains = Self.perDayStrains(recent, rest: rest, maxHR: maxHR)
             let hrvs = recent.compactMap(\.localRMSSD).filter { $0 > 0 }
             let respiratoryRates = recent.compactMap {
                 $0.sleepRespiratoryRate(rest: rest, maxHR: maxHR)
@@ -11752,7 +11768,7 @@ final class SessionStore: ObservableObject {
             let evidence = session.baselineLearningEvidence(rest: rest, maxHR: maxHR)
             return evidence.accepted ? evidence.value : nil
         }
-        let strains = recent.map { Metrics.strain(fromTRIMP: $0.trimp(rest: rest, max: maxHR)) }
+        let strains = Self.perDayStrains(recent, rest: rest, maxHR: maxHR)
         let hrvs = recent.compactMap(\.localRMSSD).filter { $0 > 0 }
         let respiratoryRates = recent.compactMap {
             $0.sleepRespiratoryRate(rest: rest, maxHR: maxHR)

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -16909,7 +16909,9 @@ struct SessionDetail: View {
     init(session: SavedSession) {
         self.session = session
         self.displayedPoints = Self.downsampledPoints(session.points)
-        self.summary = SessionDetailSummary(session: session, maxHR: AthleteProfile.load().maxHR)
+        self.summary = SessionDetailSummary(session: session,
+                                            rest: PersonalBaseline.load().restingInt ?? 60,
+                                            maxHR: AthleteProfile.load().maxHR)
     }
 
     var body: some View {
@@ -16980,14 +16982,18 @@ private struct SessionDetailSummary {
     let zoneRows: [TimeInZoneRow]
     let zoneTotal: Double
 
-    init(session: SavedSession, maxHR: Int) {
+    init(session: SavedSession, rest: Int, maxHR: Int) {
         resting = session.resting
         average = session.avg
         peak = session.peak
-        let resolvedMaxHR = max(maxHR, session.restingStable + 1)
+        // Strain uses the SAME baseline rest + profile maxHR as the day/trend
+        // rollups (2026-07-08 consistency audit) so a workout's strain
+        // reconciles everywhere. It previously used session.restingStable +
+        // a re-clamped max, which diverged from every rollup for the same
+        // workout. Zones keep a clamped max (they need max > rest).
         strainText = String(format: "%.1f",
-                            Metrics.strain(fromTRIMP: session.trimp(rest: session.restingStable,
-                                                                     max: resolvedMaxHR)))
+                            Metrics.strain(fromTRIMP: session.trimp(rest: rest, max: maxHR)))
+        let resolvedMaxHR = max(maxHR, rest + 1)
         let zoneMap = session.timeInZone(maxHR: resolvedMaxHR)
         zoneRows = HRZone.allCases.compactMap { zone in
             guard let seconds = zoneMap[zone], seconds > 0 else { return nil }

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -8555,6 +8555,10 @@ final class SessionStore: ObservableObject {
 
     private var lastForegroundSleepAutoConfirmAt: Date?
 
+    /// How long after a confirmed night's end a wake-then-sleep-again can still
+    /// extend it. Past this, the night is treated as settled (2026-07-08).
+    private static let sleepReExtendMorningWindow: TimeInterval = 5 * 60 * 60
+
     /// Foreground (morning-flow) auto-confirm: launch-time auto-confirm never fires
     /// while the app stays resident overnight, so the first foreground of the day
     /// re-runs it. Rate-limited, and skipped while the newest confirmed sleep is
@@ -8569,8 +8573,18 @@ final class SessionStore: ObservableObject {
             .filter { !Self.confirmedSleepSourceIsNap(source: $0.source, duration: $0.duration) }
             .map(\.end)
             .max()
-        if let latestOvernightEnd, now.timeIntervalSince(latestOvernightEnd) < 16 * 60 * 60 {
-            return
+        // Re-evaluate in the first few hours after a night's end so a wake-then-
+        // sleep-again can EXTEND it (user 2026-07-08), and again after 16h for a
+        // genuinely new night. Between those, the night is settled — skip.
+        let inExtendReCheckWindow: Bool
+        if let latestOvernightEnd {
+            let sinceEnd = now.timeIntervalSince(latestOvernightEnd)
+            if sinceEnd >= Self.sleepReExtendMorningWindow, sinceEnd < 16 * 60 * 60 {
+                return
+            }
+            inExtendReCheckWindow = sinceEnd < Self.sleepReExtendMorningWindow
+        } else {
+            inExtendReCheckWindow = false
         }
         lastForegroundSleepAutoConfirmAt = now
         var saved = autoConfirmStrongSleepCandidates(reason: reason)
@@ -8584,9 +8598,12 @@ final class SessionStore: ObservableObject {
             saved = evaluateWakeBoundarySleepIfUseful(reason: reason, now: now)
         }
         refreshHistorySnapshotCache(deferred: true)
-        if !saved {
+        if !saved && !inExtendReCheckWindow {
             // Back the rate limit off to ~10 min on failure so a transient
-            // blocker does not cost the whole 30-minute window.
+            // blocker does not cost the whole 30-minute window. Skipped while
+            // re-checking a settled confirmed night for extension (2026-07-08):
+            // there is nothing to retry, and the 10-min backoff would otherwise
+            // churn aggregateSleepCandidates on every morning foreground.
             lastForegroundSleepAutoConfirmAt = now.addingTimeInterval(-20 * 60)
             scheduleSleepReadinessRetryIfUseful(reason: reason)
         }
@@ -8615,6 +8632,14 @@ final class SessionStore: ObservableObject {
             let id = confirmedSleepID(start: candidate.start,
                                      end: candidate.end,
                                      source: Self.autoSleepClassification(for: candidate).source)
+            // Wake-then-sleep-again grew the night: extend the confirmed auto night
+            // in place instead of skipping the candidate as a duplicate (user
+            // 2026-07-08). applySleepExtend is extend-only and never touches a
+            // manual/adjusted night, so it can't clobber a user override.
+            if applySleepExtend(to: &existing, candidate: candidate, reason: "\(reason)_extend") != nil {
+                saved += 1
+                continue
+            }
             if existing.contains(where: { $0.id == id || Self.sleepWindowsOverlap($0, candidate: candidate) }) {
                 continue
             }
@@ -8935,6 +8960,19 @@ final class SessionStore: ObservableObject {
         // never the in-flight candidate itself, so this can't self-match.
         var existing = cachedConfirmedSleeps
         let confirmed = buildAutoConfirmedSleep(from: candidate, reason: "\(reason)_wake_boundary")
+        // Wake-then-sleep-again on a continuous (all-day-wear) recording: the live
+        // night session's wake boundary moved later, so grow the confirmed night in
+        // place rather than skip it as an overlap (user 2026-07-08). This is the
+        // path the resident-app case actually takes — the closed-candidate path
+        // never sees a still-open night.
+        if let extended = applySleepExtend(to: &existing, candidate: candidate, reason: "\(reason)_wake_boundary_extend") {
+            saveConfirmedSleeps(existing)
+            AtriaDebugLog("ATRIADBG sleep_wake_boundary status=extended reason=%@ id=%@ end=%@",
+                          reason, extended.id, isoString(extended.end))
+            DetectionEventLog.append(DetectionEvent(kind: "sleepAutoConfirmed",
+                                                     detail: "extended to \(isoString(extended.end)) (wake boundary)"))
+            return true
+        }
         guard !existing.contains(where: { $0.id == confirmed.id || Self.sleepWindowsOverlap($0, candidate: candidate) }) else {
             AtriaDebugLog("ATRIADBG sleep_wake_boundary status=overlaps_saved reason=%@ id=%@", reason, confirmed.id)
             DetectionEventLog.append(DetectionEvent(kind: "sleepCandidateSkipped",
@@ -8956,6 +8994,28 @@ final class SessionStore: ObservableObject {
         DetectionEventLog.append(DetectionEvent(kind: "sleepAutoConfirmed",
                                                  detail: "\(isoString(confirmed.start))–\(isoString(confirmed.end)), \(SleepHistorySnapshot.formatDuration(confirmed.duration)) (wake boundary)"))
         return true
+    }
+
+    /// Extend an existing confirmed auto night in place when `candidate` grows it
+    /// (wake-then-sleep-again). Mutates `existing`, returns the extended record
+    /// (nil = no extend). Shared by the closed-candidate and wake-boundary paths.
+    /// Keeps the transient auto-logged banner in sync but never re-notifies.
+    @discardableResult
+    private func applySleepExtend(to existing: inout [UserConfirmedSleep],
+                                  candidate: AggregateSleepCandidate,
+                                  reason: String) -> UserConfirmedSleep? {
+        guard Self.sleepExtendReplacement(existing: existing, candidate: candidate) else { return nil }
+        existing.removeAll { Self.isExtendableAutoNight($0) && Self.sleepWindowsOverlap($0, candidate: candidate) }
+        let extended = buildAutoConfirmedSleep(from: candidate, reason: reason)
+        existing.append(extended)
+        if let banner = autoSleepLoggedBanner, banner.start < candidate.end, banner.end > candidate.start {
+            autoSleepLoggedBanner = AutoSleepLoggedBanner(id: extended.id,
+                                                          start: extended.start,
+                                                          end: extended.end,
+                                                          duration: extended.duration,
+                                                          sleepID: extended.id)
+        }
+        return extended
     }
 
     /// Exposed (not `private`) so unit tests can exercise the auto-confirm gate
@@ -9106,6 +9166,45 @@ final class SessionStore: ObservableObject {
 
     private nonisolated static func sleepWindowsOverlap(_ sleep: UserConfirmedSleep, candidate: AggregateSleepCandidate) -> Bool {
         sleep.start < candidate.end && sleep.end > candidate.start
+    }
+
+    /// A source the user authored or hand-edited — never touched by the auto
+    /// extend path (2026-07-08). Covers manual_sleep/manual_nap and the
+    /// user_adjusted_* sources produced by the Adjust sheet.
+    nonisolated static func isUserAuthoredSleepSource(_ source: String) -> Bool {
+        source.hasPrefix("manual_") || source.hasPrefix("user_adjusted_")
+    }
+
+    /// A confirmed night the auto extend may grow in place: a real overnight sleep
+    /// (not a nap) that the user did not author/edit.
+    nonisolated static func isExtendableAutoNight(_ sleep: UserConfirmedSleep) -> Bool {
+        !confirmedSleepSourceIsNap(source: sleep.source, duration: sleep.duration)
+            && !isUserAuthoredSleepSource(sleep.source)
+    }
+
+    /// Whether `candidate` should EXTEND the confirmed overnight night(s) it
+    /// overlaps rather than be skipped as a duplicate — "wake, then sleep again"
+    /// (user 2026-07-08). Extend-ONLY and safe:
+    ///  - never for a nap candidate;
+    ///  - never when it overlaps a USER-authored/edited night (left strictly alone);
+    ///  - only as a TAIL-superset of the auto night(s) it overlaps: it starts no
+    ///    later than their earliest start (so it can't trim the head, and a
+    ///    later-starting cluster split off by a >2h strap-dead gap is refused
+    ///    rather than fabricating sleep across the gap) AND ends meaningfully
+    ///    later than their latest end.
+    /// So it can only GROW an auto night — never shrink, split, or clobber a manual one.
+    nonisolated static func sleepExtendReplacement(existing: [UserConfirmedSleep],
+                                                   candidate: AggregateSleepCandidate,
+                                                   minGain: TimeInterval = 5 * 60) -> Bool {
+        guard candidate.kind != "nap_candidate" else { return false }
+        if existing.contains(where: { isUserAuthoredSleepSource($0.source) && sleepWindowsOverlap($0, candidate: candidate) }) {
+            return false
+        }
+        let overlappingNights = existing.filter { isExtendableAutoNight($0) && sleepWindowsOverlap($0, candidate: candidate) }
+        guard let latestEnd = overlappingNights.map(\.end).max(),
+              let earliestStart = overlappingNights.map(\.start).min() else { return false }
+        return candidate.start <= earliestStart
+            && candidate.end > latestEnd.addingTimeInterval(minGain)
     }
 
     func addManualSleep(start: Date,
@@ -9573,7 +9672,7 @@ final class SessionStore: ObservableObject {
                                          idPrefix: "migrated")
     }
 
-    private static func confirmedSleepSourceIsNap(source: String, duration: TimeInterval) -> Bool {
+    nonisolated static func confirmedSleepSourceIsNap(source: String, duration: TimeInterval) -> Bool {
         if SleepHistorySnapshot.Night.explicitNapSources.contains(source) {
             return true
         }

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -4478,8 +4478,12 @@ final class SessionStore: ObservableObject {
         }
         let daySessionsExist = !wearSessionsToday.isEmpty
         let wearRestingHR = wearSessionsToday.map(\.restingStable).filter { $0 > 0 }.min()
+        // Same rest anchor as the primary rollup strain (2026-07-08 audit #14:
+        // baseline.restingInt ?? 60), so today's strain is identical whether it
+        // comes from computedToday or this wear fallback. Previously this branch
+        // added `?? wearRestingHR`, diverging when no baseline exists yet.
         let wearStrainTRIMP = wearSessionsToday.reduce(0.0) {
-            $0 + $1.trimp(rest: baseline.restingInt ?? wearRestingHR ?? 60, max: maxHR)
+            $0 + $1.trimp(rest: baseline.restingInt ?? 60, max: maxHR)
         }
         let wearStrain = wearStrainTRIMP > 0 ? Metrics.strain(fromTRIMP: wearStrainTRIMP) : nil
 

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -3025,11 +3025,19 @@ extension SavedSession {
                                                 ? "validated_hrv_window"
                                                 : "local_hrv_window")
         }
-        if duration < 20 * 60 {
+        // Duration floor lowered 20min -> 5min (2026-07-08, device-reported
+        // "1/14 RHR" after 3 days). All-day wear, fragmented by frequent BLE
+        // drops into sub-20-min segments, was silently discarding genuinely
+        // restful data. This reject still sits BEFORE the avg<=rest+15 /
+        // peak<=rest+35 guards below, so a 5-20 min segment must still prove
+        // it is truly at rest to be accepted; sub-5-min stays rejected. The
+        // 14-distinct-DAY trust gate and bounded EMA are untouched, so
+        // learning states still fail closed until real multi-day history.
+        if duration < 5 * 60 {
             return BaselineLearningEvidence(value: restingEvidence.value,
                                             source: restingEvidence.source,
                                             accepted: false,
-                                            reason: "duration_below_20m")
+                                            reason: "duration_below_5m")
         }
         if avg > rest + 15 {
             return BaselineLearningEvidence(value: restingEvidence.value,

--- a/Atria/Atria/Sessions.swift
+++ b/Atria/Atria/Sessions.swift
@@ -3365,6 +3365,10 @@ final class SessionStore: ObservableObject {
     /// marker changes so SwiftUI renders read O(1) values.
     @Published private(set) var imuAuditSummary = IMUAuditSummary(sessions: [])
     @Published private(set) var researchManeuverProbeCorrelationSummary = ResearchManeuverProbeCorrelationSummary(markers: [], sessions: [])
+    /// Coalesces the off-main recompute of the research/collection summaries so
+    /// they don't rebuild over ALL sessions on the main thread on every live
+    /// checkpoint (2026-07-08 compute-cadence pass).
+    private var pendingResearchSummaryRecompute: DispatchWorkItem?
     /// History opens with this cached snapshot instead of recomputing activity
     /// detection, trend summaries, and daily rollups on the navigation path.
     @Published private(set) var historySnapshot = HistorySnapshot.empty
@@ -3486,9 +3490,23 @@ final class SessionStore: ObservableObject {
     }
 
     private func recomputeCollectionResearchSummaries() {
-        imuAuditSummary = IMUAuditSummary(sessions: sessions)
-        researchManeuverProbeCorrelationSummary = ResearchManeuverProbeCorrelationSummary(markers: cachedResearchManeuverMarkers,
-                                                                                          sessions: sessions)
+        // These feed non-live research/collection cards, so coalesce them off the
+        // hot sessions.didSet (fires on every live checkpoint) and compute OFF the
+        // main thread — rebuilding IMUAuditSummary + the maneuver correlation over
+        // ALL sessions on the main thread on every mutation was a stall (2026-07-08).
+        pendingResearchSummaryRecompute?.cancel()
+        let sessionsSnapshot = sessions
+        let markers = cachedResearchManeuverMarkers
+        let work = DispatchWorkItem {
+            let imu = IMUAuditSummary(sessions: sessionsSnapshot)
+            let maneuver = ResearchManeuverProbeCorrelationSummary(markers: markers, sessions: sessionsSnapshot)
+            DispatchQueue.main.async { [weak self] in
+                self?.imuAuditSummary = imu
+                self?.researchManeuverProbeCorrelationSummary = maneuver
+            }
+        }
+        pendingResearchSummaryRecompute = work
+        DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.4, execute: work)
     }
 
     private func refreshHistorySnapshotCache(deferred: Bool = true) {

--- a/Atria/Atria/WidgetSnapshot.swift
+++ b/Atria/Atria/WidgetSnapshot.swift
@@ -262,7 +262,10 @@ enum WidgetSnapshotPublisher {
     /// Falls back to a full recompute when the sample prefix, rest, or max HR no
     /// longer match the cached state (e.g. after a live-session rollover clears
     /// `ble.session`, or the resting/max baseline changed).
-    private static func incrementalLiveTRIMP(samples: [HRSample], rest: Int, max: Int) -> Double {
+    // Internal (was private) so LocalNotificationScheduler reuses this same
+    // incremental accumulator instead of re-integrating the whole live session
+    // (2026-07-08 perf audit). Both are @MainActor, so the cache stays race-free.
+    static func incrementalLiveTRIMP(samples: [HRSample], rest: Int, max: Int) -> Double {
         guard max > rest, samples.count > 1 else {
             liveTRIMPSampleCount = samples.count
             liveTRIMPLastTimestamp = samples.last?.t

--- a/Atria/AtriaTests/AtriaAnalyticsTests.swift
+++ b/Atria/AtriaTests/AtriaAnalyticsTests.swift
@@ -1515,6 +1515,42 @@ final class AtriaAnalyticsTests: XCTestCase {
         XCTAssertTrue(result.zonePath)
     }
 
+    // Device-lag fix (2026-07-07): the evaluator now walks only the trailing
+    // window instead of scanning the whole (up to ~80k-sample) session. These
+    // lock that the long lead-in neither counts nor changes the verdict.
+    func testWorkoutPromptEvaluatorScansOnlyTailOfLongSession() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        // ~4h of resting samples before the window, then 8 min elevated ending now.
+        let leadIn = syntheticHeartSamples(start: start, count: 14_400, bpm: 62)
+        let tail = syntheticHeartSamples(start: start.addingTimeInterval(14_400), count: 480, bpm: 87)
+        let samples = leadIn + tail
+
+        let result = AtriaWorkoutPromptEvaluator.evaluate(samples: samples,
+                                                          currentHeartRate: 87,
+                                                          restingHeartRate: 60,
+                                                          maxHeartRate: 190,
+                                                          now: samples.last!.t)
+        XCTAssertEqual(result.elevatedSamples, 480, "only the trailing 8-min window counts")
+        XCTAssertTrue(result.sustainedPath)
+        XCTAssertTrue(result.shouldPrompt)
+    }
+
+    func testWorkoutPromptEvaluatorIgnoresElevatedDataBeforeWindow() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        // Old elevated bout long ago, then the last 8 min at rest.
+        let oldElevated = syntheticHeartSamples(start: start, count: 480, bpm: 120)
+        let recentResting = syntheticHeartSamples(start: start.addingTimeInterval(3_600), count: 480, bpm: 62)
+        let samples = oldElevated + recentResting
+
+        let result = AtriaWorkoutPromptEvaluator.evaluate(samples: samples,
+                                                          currentHeartRate: 62,
+                                                          restingHeartRate: 60,
+                                                          maxHeartRate: 190,
+                                                          now: samples.last!.t)
+        XCTAssertEqual(result.elevatedSamples, 0, "elevated data outside the window must not count")
+        XCTAssertFalse(result.shouldPrompt)
+    }
+
     func testWorkoutPromptCooldownLatchExpiresAfterFortyFiveMinutes() {
         let now = Date(timeIntervalSince1970: 1_800_000_000)
         let dismissedUntil = now.addingTimeInterval(AtriaWorkoutPromptEvaluator.cooldown)

--- a/Atria/AtriaTests/AtriaAnalyticsTests.swift
+++ b/Atria/AtriaTests/AtriaAnalyticsTests.swift
@@ -1309,6 +1309,51 @@ final class AtriaAnalyticsTests: XCTestCase {
         XCTAssertEqual(rate ?? 0, 15.0, accuracy: 1.0)
     }
 
+    // MARK: Respiratory-rate HF band floor + BLE-gap guard (2026-07-08)
+
+    func testRespRateAcceptsRealBreathingBand() {
+        let sampleRate = 4.0
+        let count = Int(90 * sampleRate)
+        let hf = (0..<count).map { sin(2 * Double.pi * (15.0 / 60.0) * Double($0) / sampleRate) }
+        let rate = AtriaAnalytics.RespRateRsa.estimate(resampledRR: hf, sampleRate: sampleRate)
+        XCTAssertNotNil(rate)
+        XCTAssertEqual(rate ?? 0, 15.0, accuracy: 1.0)
+    }
+
+    func testRespRateNeverReportsBelowBreathingFloor() {
+        // A 6 bpm (0.10 Hz) oscillation is HRV low-frequency / Mayer-wave
+        // territory, not breathing. The device showed 6.5-8.2 bpm reported as
+        // respiratory rate — a fabrication. The estimator must now never
+        // return a value below the 9 bpm HF-band floor (nil is fine).
+        let sampleRate = 4.0
+        let count = Int(90 * sampleRate)
+        let lf = (0..<count).map { sin(2 * Double.pi * (6.0 / 60.0) * Double($0) / sampleRate) }
+        if let rate = AtriaAnalytics.RespRateRsa.estimate(resampledRR: lf, sampleRate: sampleRate) {
+            XCTAssertGreaterThanOrEqual(rate, 9.0, "must not report LF drift as sub-9 bpm breathing")
+        }
+    }
+
+    func testRespRateFailsClosedAcrossBleDropGap() {
+        // A clean 15 bpm RR series with a 12s beat-timeline hole (BLE drop).
+        // The gap guard must return nil rather than interpolate LF drift
+        // across the hole and mislabel it as slow breathing.
+        let base = Date(timeIntervalSinceReferenceDate: 900_000)
+        var samples: [(t: Date, ms: Double)] = []
+        for index in 0..<220 {
+            let t = Double(index) * 0.9
+            let ms = 900 + 70 * sin(2 * Double.pi * (15.0 / 60.0) * t)
+            samples.append((base.addingTimeInterval(t), ms))
+        }
+        let afterGap = samples.last!.t.addingTimeInterval(12)
+        for index in 0..<120 {
+            let t = Double(index) * 0.9
+            let ms = 900 + 70 * sin(2 * Double.pi * (15.0 / 60.0) * t)
+            samples.append((afterGap.addingTimeInterval(t), ms))
+        }
+        let now = samples.last!.t
+        XCTAssertNil(AtriaAnalytics.RespRateRsa.estimate(samples: samples, now: now, lookback: 600))
+    }
+
     func testSleepRespiratoryRateFallsBackForOvernightHROnlyEvidence() {
         var calendar = Calendar(identifier: .gregorian)
         calendar.timeZone = TimeZone(secondsFromGMT: 0)!

--- a/Atria/AtriaTests/AtriaAnalyticsTests.swift
+++ b/Atria/AtriaTests/AtriaAnalyticsTests.swift
@@ -2361,9 +2361,10 @@ final class AtriaAnalyticsTests: XCTestCase {
             AtriaHomeModel.HeartRateChartPoint(t: start.addingTimeInterval(180), bpm: 92),
         ]
 
+        // Merge de-dups by second (live overrides historical at t=120) and
+        // sorts ascending; it no longer pre-downsamples (2026-07-07 rework).
         let merged = AtriaVitalsHeartRateTimeline.mergedHeartRatePoints(live: live,
-                                                                        historical: historical,
-                                                                        targetCount: 10)
+                                                                        historical: historical)
 
         XCTAssertEqual(merged.map { Int($0.t.timeIntervalSince(start)) }, [0, 60, 120, 180])
         XCTAssertEqual(merged.map(\.bpm), [61, 62, 91, 92])

--- a/Atria/AtriaTests/AtriaAssistantAnswerTests.swift
+++ b/Atria/AtriaTests/AtriaAssistantAnswerTests.swift
@@ -7,7 +7,10 @@ import SwiftUI
 /// not enough data" line and never invents a number.
 @MainActor
 final class AtriaAssistantAnswerTests: XCTestCase {
-    private func makeScreen(recoveryText: String = "--") -> AtriaAssistantScreen {
+    // "Learning" is the sentinel production actually emits (HeroSnapshot
+    // .recoveryValue) when there's no score — not "--". Exercising the real
+    // value is what caught the recovery guard bug (2026-07-08 self-review).
+    private func makeScreen(recoveryText: String = "Learning") -> AtriaAssistantScreen {
         let context = AtriaCoachContext(guidance: Coach.guide(recovery: 0, strain: 0),
                                         strain: 0, recoveryText: recoveryText, hrvText: "--",
                                         stressText: "--", baselineSamples: 0, sessionsCount: 0)

--- a/Atria/AtriaTests/AtriaAssistantAnswerTests.swift
+++ b/Atria/AtriaTests/AtriaAssistantAnswerTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+import SwiftUI
+@testable import Atria
+
+/// Assistant deterministic answers (2026-07-08): the honesty LAW is that
+/// with no recorded data every answer fails closed to a "still learning /
+/// not enough data" line and never invents a number.
+@MainActor
+final class AtriaAssistantAnswerTests: XCTestCase {
+    private func makeScreen(recoveryText: String = "--") -> AtriaAssistantScreen {
+        let context = AtriaCoachContext(guidance: Coach.guide(recovery: 0, strain: 0),
+                                        strain: 0, recoveryText: recoveryText, hrvText: "--",
+                                        stressText: "--", baselineSamples: 0, sessionsCount: 0)
+        return AtriaAssistantScreen(
+            store: SessionStore(), context: context, coachPayload: nil,
+            aiCoachSettings: AtriaAICoachSettings(), aiCoachHasAPIKey: false,
+            onAICoachSettingsChange: { _ in }, onSaveAICoachAPIKey: { _ in }, onDeleteAICoachAPIKey: {})
+    }
+
+    func testEmptyStoreFailsClosedNeverFabricates() {
+        let screen = makeScreen()
+        let expectations: [(id: String, mustMention: String)] = [
+            ("recovery", "learning"),
+            ("sleep", "confirmed night"),
+            ("typical", "building"),
+            ("behaviors", "statistical bar"),
+            ("week", "Not enough"),
+        ]
+        for expectation in expectations {
+            let result = screen.debugAnswer(promptID: expectation.id)
+            XCTAssertTrue(result.answer.localizedCaseInsensitiveContains(expectation.mustMention),
+                          "\(expectation.id) answer should fail closed; got: \(result.answer)")
+            // No fabricated percentage or ms reading in a fail-closed answer.
+            XCTAssertFalse(result.answer.contains("%"),
+                           "\(expectation.id) fail-closed answer must not state a percent: \(result.answer)")
+        }
+    }
+
+    func testEveryAnswerCitesItsProvenance() {
+        let screen = makeScreen()
+        for prompt in ["recovery", "sleep", "typical", "behaviors", "week"] {
+            let result = screen.debugAnswer(promptID: prompt)
+            XCTAssertFalse(result.provenance.isEmpty, "\(prompt) must state where its answer came from")
+        }
+    }
+}

--- a/Atria/AtriaTests/AtriaBaselineEvidenceTests.swift
+++ b/Atria/AtriaTests/AtriaBaselineEvidenceTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Atria
+
+/// Baseline resting-sample acceptance floor (2026-07-08, device-reported
+/// "1/14 RHR" after 3 days). All-day wear fragmented by frequent BLE drops
+/// into sub-20-min segments was silently discarding genuinely restful data,
+/// stalling the RHR baseline. The floor is now 5 min; the avg/peak
+/// rest-window guards still decide what actually counts as resting, so
+/// elevated segments never pollute the resting norm.
+final class AtriaBaselineEvidenceTests: XCTestCase {
+    private var calendar: Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "America/New_York")!
+        return calendar
+    }
+
+    /// A fixed midday instant so restingHRForBaseline never takes the
+    /// sleep-candidate path (a short daytime window is neither overnight nor
+    /// long enough to be a nap).
+    private func middaySession(durationSeconds: Double, bpm: Int) -> SavedSession {
+        let start = DateComponents(calendar: calendar, year: 2026, month: 7, day: 1,
+                                   hour: 12, minute: 0).date!
+        let points = stride(from: 0.0, through: durationSeconds, by: 10.0).map {
+            SavedSession.Point(t: $0, bpm: bpm)
+        }
+        return SavedSession(id: UUID(),
+                            start: start,
+                            end: start.addingTimeInterval(durationSeconds),
+                            label: "Rest",
+                            points: points,
+                            respiratoryRate: nil,
+                            rrPoints: nil,
+                            sleepWakeResearchState: nil)
+    }
+
+    func testRestfulTenMinuteSegmentNowAccepted() {
+        // 10 min at 65 bpm, rest 60: previously rejected "duration_below_20m",
+        // now clears the 5-min floor and the avg/peak guards.
+        let evidence = middaySession(durationSeconds: 600, bpm: 65)
+            .baselineLearningEvidence(rest: 60, maxHR: 190, calendar: calendar)
+        XCTAssertTrue(evidence.accepted, "genuinely restful 10-min segment must count")
+        XCTAssertEqual(evidence.reason, "low_hr_window")
+    }
+
+    func testElevatedTenMinuteSegmentStillRejected() {
+        // 10 min at 90 bpm, rest 60: above rest+15, must NOT pollute the
+        // resting baseline even though it now clears the duration floor.
+        let evidence = middaySession(durationSeconds: 600, bpm: 90)
+            .baselineLearningEvidence(rest: 60, maxHR: 190, calendar: calendar)
+        XCTAssertFalse(evidence.accepted)
+        XCTAssertEqual(evidence.reason, "avg_hr_above_rest_window")
+    }
+
+    func testSubFiveMinuteSegmentStillRejected() {
+        // 4 min at 65 bpm: too short to trust, still fails closed.
+        let evidence = middaySession(durationSeconds: 240, bpm: 65)
+            .baselineLearningEvidence(rest: 60, maxHR: 190, calendar: calendar)
+        XCTAssertFalse(evidence.accepted)
+        XCTAssertEqual(evidence.reason, "duration_below_5m")
+    }
+}

--- a/Atria/AtriaTests/AtriaDataSharingPolicyTests.swift
+++ b/Atria/AtriaTests/AtriaDataSharingPolicyTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import Atria
+
+/// Opt-in data-sharing transmission policy (2026-07-08): the user's rule is
+/// "only transmit while asleep OR not using the phone." These lock every
+/// branch and the precedence order so the wiring (next) can't drift from it.
+final class AtriaDataSharingPolicyTests: XCTestCase {
+    private func decide(optedIn: Bool = true,
+                        hasPending: Bool = true,
+                        sleep: Bool = false,
+                        idle: Bool = false,
+                        battery: Double = 0.8,
+                        charging: Bool = false) -> AtriaResearchUploadQueue.TransmitDecision {
+        AtriaResearchUploadQueue.transmissionEligibility(
+            optedIn: optedIn, hasPending: hasPending, withinSleepWindow: sleep,
+            phoneIdle: idle, batteryFraction: battery, isCharging: charging)
+    }
+
+    func testHoldsWhenNotOptedIn() {
+        // Opt-out beats everything, even asleep with a full battery.
+        XCTAssertEqual(decide(optedIn: false, sleep: true), .hold(reason: "sharing_off"))
+    }
+
+    func testHoldsWhenNothingToSend() {
+        XCTAssertEqual(decide(hasPending: false, sleep: true), .hold(reason: "nothing_pending"))
+    }
+
+    func testTransmitsWhileAsleep() {
+        XCTAssertEqual(decide(sleep: true), .eligible(reason: "sleep_window"))
+    }
+
+    func testTransmitsWhilePhoneIdleAndAwake() {
+        XCTAssertEqual(decide(sleep: false, idle: true), .eligible(reason: "phone_idle"))
+    }
+
+    func testHoldsWhileAwakeAndUsingPhone() {
+        XCTAssertEqual(decide(sleep: false, idle: false), .hold(reason: "phone_in_use"))
+    }
+
+    func testHoldsOnLowBatteryUnplugged() {
+        // Low battery holds even while asleep — battery care outranks the
+        // sleep/idle window.
+        XCTAssertEqual(decide(sleep: true, battery: 0.10, charging: false),
+                       .hold(reason: "low_battery"))
+    }
+
+    func testLowBatteryButChargingDoesNotBlock() {
+        XCTAssertEqual(decide(sleep: true, battery: 0.10, charging: true),
+                       .eligible(reason: "sleep_window"))
+    }
+
+    func testUnknownBatteryNeverBlocks() {
+        // Negative = monitoring off / unknown: the battery guard fails open,
+        // the sleep/idle window still governs.
+        XCTAssertEqual(decide(idle: true, battery: -1, charging: false),
+                       .eligible(reason: "phone_idle"))
+        XCTAssertEqual(decide(sleep: false, idle: false, battery: -1),
+                       .hold(reason: "phone_in_use"))
+    }
+
+    func testPrecedenceOptOutBeatsPendingAndBattery() {
+        XCTAssertEqual(decide(optedIn: false, hasPending: false, battery: 0.05),
+                       .hold(reason: "sharing_off"))
+    }
+
+    func testIsEligibleAndReasonAccessors() {
+        XCTAssertTrue(decide(sleep: true).isEligible)
+        XCTAssertFalse(decide().isEligible)
+        XCTAssertEqual(decide(sleep: true).reason, "sleep_window")
+        XCTAssertEqual(decide().reason, "phone_in_use")
+    }
+}

--- a/Atria/AtriaTests/AtriaHeartRateTimelineWindowTests.swift
+++ b/Atria/AtriaTests/AtriaHeartRateTimelineWindowTests.swift
@@ -52,4 +52,26 @@ final class AtriaHeartRateTimelineWindowTests: XCTestCase {
         XCTAssertGreaterThan(merged.count, 180, "must not pre-downsample to 180 or the 1-min zoom loses detail")
         XCTAssertEqual(merged, merged.sorted { $0.t < $1.t })
     }
+    func testPinchOutZoomsIn() {
+        // anchor 12h (index 7), pinch out 2x -> ~2 steps shorter window (6h, index 5).
+        let idx = AtriaVitalsHeartRateTimeline.windowIndex(fromPinchAnchor: 7, magnification: 2, maxIndex: 8)
+        XCTAssertEqual(idx, 5, accuracy: 0.5)
+    }
+
+    func testPinchInZoomsOutAndClamps() {
+        // anchor 12h, pinch in to 0.5 -> ~2 steps wider (24h, clamped to 8).
+        let idx = AtriaVitalsHeartRateTimeline.windowIndex(fromPinchAnchor: 7, magnification: 0.5, maxIndex: 8)
+        XCTAssertEqual(idx, 8, accuracy: 0.01)
+    }
+
+    func testPinchClampsAtFloor() {
+        let idx = AtriaVitalsHeartRateTimeline.windowIndex(fromPinchAnchor: 0, magnification: 8, maxIndex: 8)
+        XCTAssertEqual(idx, 0, accuracy: 0.01)
+    }
+
+    func testNoPinchKeepsAnchor() {
+        let idx = AtriaVitalsHeartRateTimeline.windowIndex(fromPinchAnchor: 4, magnification: 1, maxIndex: 8)
+        XCTAssertEqual(idx, 4, accuracy: 0.01)
+    }
 }
+

--- a/Atria/AtriaTests/AtriaHeartRateTimelineWindowTests.swift
+++ b/Atria/AtriaTests/AtriaHeartRateTimelineWindowTests.swift
@@ -1,0 +1,55 @@
+import XCTest
+@testable import Atria
+
+/// HR-timeline time-window zoom (2026-07-07, user request: 12h default, zoom
+/// in to 1 min, out to 24h). Locks the windowing math and that the merge no
+/// longer pre-downsamples away the resolution the tight zoom needs.
+final class AtriaHeartRateTimelineWindowTests: XCTestCase {
+    private func points(spanHours: Double, count: Int, endingAt end: Date) -> [AtriaHomeModel.HeartRateChartPoint] {
+        let span = spanHours * 3600
+        return (0..<count).map { index in
+            let t = end.addingTimeInterval(-span + span * Double(index) / Double(max(count - 1, 1)))
+            return AtriaHomeModel.HeartRateChartPoint(t: t, bpm: 70)
+        }
+    }
+
+    func testDefaultWindowIsTwelveHours() {
+        XCTAssertEqual(AtriaVitalsHeartRateTimeline.Window.defaultWindow, .hour12)
+        XCTAssertEqual(AtriaVitalsHeartRateTimeline.Window.hour12.seconds, 12 * 3600, accuracy: 0.5)
+        XCTAssertEqual(AtriaVitalsHeartRateTimeline.Window.min1.seconds, 60, accuracy: 0.5)
+        XCTAssertEqual(AtriaVitalsHeartRateTimeline.Window.hour24.seconds, 24 * 3600, accuracy: 0.5)
+    }
+
+    func testWindowedKeepsOnlyLastTwelveHoursOfDay() {
+        let end = Date(timeIntervalSince1970: 1_800_000_000)
+        let pts = points(spanHours: 24, count: 1440, endingAt: end)
+        let windowed = AtriaVitalsHeartRateTimeline.windowed(pts, window: .hour12, displayBudget: 10_000)
+        XCTAssertTrue(windowed.allSatisfy { $0.t >= end.addingTimeInterval(-12 * 3600) })
+        XCTAssertLessThan(windowed.count, pts.count)
+        XCTAssertGreaterThan(windowed.count, 600)
+    }
+
+    func testWindowedOneMinuteKeepsOnlyLastMinute() {
+        let end = Date(timeIntervalSince1970: 1_800_000_000)
+        let pts = points(spanHours: 2, count: 7200, endingAt: end)
+        let windowed = AtriaVitalsHeartRateTimeline.windowed(pts, window: .min1, displayBudget: 10_000)
+        XCTAssertTrue(windowed.allSatisfy { $0.t >= end.addingTimeInterval(-60) })
+        XCTAssertLessThanOrEqual(windowed.count, 62)
+        XCTAssertGreaterThan(windowed.count, 0)
+    }
+
+    func testWindowedDownsamplesToBudget() {
+        let end = Date(timeIntervalSince1970: 1_800_000_000)
+        let pts = points(spanHours: 12, count: 5000, endingAt: end)
+        XCTAssertEqual(AtriaVitalsHeartRateTimeline.windowed(pts, window: .hour12, displayBudget: 200).count, 200)
+    }
+
+    func testMergedKeepsFullResolution() {
+        let end = Date(timeIntervalSince1970: 1_800_000_000)
+        let historical = points(spanHours: 12, count: 720, endingAt: end.addingTimeInterval(-3600))
+        let live = points(spanHours: 1, count: 300, endingAt: end)
+        let merged = AtriaVitalsHeartRateTimeline.mergedHeartRatePoints(live: live, historical: historical)
+        XCTAssertGreaterThan(merged.count, 180, "must not pre-downsample to 180 or the 1-min zoom loses detail")
+        XCTAssertEqual(merged, merged.sorted { $0.t < $1.t })
+    }
+}

--- a/Atria/AtriaTests/AtriaHeartRateTimelineWindowTests.swift
+++ b/Atria/AtriaTests/AtriaHeartRateTimelineWindowTests.swift
@@ -73,5 +73,37 @@ final class AtriaHeartRateTimelineWindowTests: XCTestCase {
         let idx = AtriaVitalsHeartRateTimeline.windowIndex(fromPinchAnchor: 4, magnification: 1, maxIndex: 8)
         XCTAssertEqual(idx, 4, accuracy: 0.01)
     }
+
+    // downsampledSpan bounds the point count while PRESERVING the time span, so
+    // the "last 12h/24h" windows can actually fill (2026-07-08 fix: historical
+    // was capped to ~6000 raw ~1 Hz samples ≈ 100 min, so 12h showed ~1.7h).
+    func testDownsampledSpanPreservesEndpointsAndBounds() {
+        let end = Date(timeIntervalSince1970: 1_800_000_000)
+        let dense = points(spanHours: 24, count: 50_000, endingAt: end)
+        let thinned = AtriaVitalsHeartRateTimeline.downsampledSpan(dense, maxPoints: 2_500)
+        XCTAssertEqual(thinned.count, 2_500)
+        XCTAssertEqual(thinned.first?.t, dense.first?.t, "first sample (span start) must be preserved")
+        XCTAssertEqual(thinned.last?.t, dense.last?.t, "last sample (span end) must be preserved")
+        XCTAssertEqual(thinned, thinned.sorted { $0.t < $1.t }, "must stay time-ordered")
+    }
+
+    func testDownsampledSpanIsNoOpWhenAlreadyUnderBudget() {
+        let end = Date(timeIntervalSince1970: 1_800_000_000)
+        let sparse = points(spanHours: 3, count: 200, endingAt: end)
+        XCTAssertEqual(AtriaVitalsHeartRateTimeline.downsampledSpan(sparse, maxPoints: 2_500), sparse)
+    }
+
+    // Regression for the actual complaint: 24h of history thinned to 2500 must
+    // still let the 12h window reach ~12h back (not the old ~1.7h).
+    func testDownsampledSpanStillFillsTwelveHourWindow() {
+        let end = Date(timeIntervalSince1970: 1_800_000_000)
+        let dense = points(spanHours: 24, count: 50_000, endingAt: end)
+        let thinned = AtriaVitalsHeartRateTimeline.downsampledSpan(dense, maxPoints: 2_500)
+        let windowed = AtriaVitalsHeartRateTimeline.windowed(thinned, window: .hour12, displayBudget: 400)
+        let earliest = windowed.first?.t ?? end
+        XCTAssertLessThanOrEqual(earliest.timeIntervalSince(end.addingTimeInterval(-12 * 3600)), 40,
+                                 "12h window must reach ~12h back, within one downsample step")
+        XCTAssertGreaterThan(windowed.count, 200)
+    }
 }
 

--- a/Atria/AtriaTests/AtriaJournalStoreTests.swift
+++ b/Atria/AtriaTests/AtriaJournalStoreTests.swift
@@ -36,6 +36,24 @@ final class AtriaJournalStoreTests: XCTestCase {
         return try JSONDecoder.atriaJournal.decode(AtriaJournalValue.self, from: data)
     }
 
+    // MARK: - 0. Typed questions
+
+    func testSubjectiveScaleQuestionsAreWellFormed() throws {
+        // Energy + focus (2026-07-08) join the daily journal as scale questions.
+        for q in [AtriaJournalTypedQuestion.energyScale, .focusScale] {
+            XCTAssertTrue(AtriaJournalTypedQuestion.allCases.contains(q))
+            XCTAssertFalse(q.title.isEmpty)
+            XCTAssertFalse(q.symbolName.isEmpty)
+            XCTAssertFalse(q.insightLabel.isEmpty)
+            XCTAssertNil(q.linkedTag, "subjective scales refine no legacy boolean tag")
+        }
+        // Their answers persist + round-trip via the generic scale value.
+        XCTAssertEqual(try roundTrip(.scale(4)), .scale(4))
+        // Every question keeps a distinct rawValue so answer series never collide.
+        let ids = AtriaJournalTypedQuestion.allCases.map(\.rawValue)
+        XCTAssertEqual(Set(ids).count, ids.count)
+    }
+
     // MARK: - 1. Codable round-trips and decode-side clamping
 
     func testJournalValueCodableRoundTripsAndClampsOnDecode() throws {

--- a/Atria/AtriaTests/AtriaJournalStoreTests.swift
+++ b/Atria/AtriaTests/AtriaJournalStoreTests.swift
@@ -40,7 +40,7 @@ final class AtriaJournalStoreTests: XCTestCase {
 
     func testSubjectiveScaleQuestionsAreWellFormed() throws {
         // Energy + focus (2026-07-08) join the daily journal as scale questions.
-        for q in [AtriaJournalTypedQuestion.energyScale, .focusScale] {
+        for q in [AtriaJournalTypedQuestion.energyScale, .focusScale, .windDownScale] {
             XCTAssertTrue(AtriaJournalTypedQuestion.allCases.contains(q))
             XCTAssertFalse(q.title.isEmpty)
             XCTAssertFalse(q.symbolName.isEmpty)

--- a/Atria/AtriaTests/AtriaPolicyMathTests.swift
+++ b/Atria/AtriaTests/AtriaPolicyMathTests.swift
@@ -166,4 +166,22 @@ final class AtriaPolicyMathTests: XCTestCase {
                                                                         now: day2,
                                                                         defaults: defaults))
     }
+
+    // Morning journal check-in timing (2026-07-08): fires at learned wake + 15
+    // min, where the duty-cycle window end is median wake + 1 h.
+    func testMorningNudgeIsWakePlusFifteen() {
+        // windowEnd 08:00 (480) => wake 07:00 => nudge 07:15 (435).
+        XCTAssertEqual(LocalNotificationScheduler.morningNudgeMinutes(windowEnd: 8 * 60), 7 * 60 + 15)
+    }
+
+    func testMorningNudgeFallsBackToEightAMWhenUnlearned() {
+        XCTAssertEqual(LocalNotificationScheduler.morningNudgeMinutes(windowEnd: 0), 8 * 60)
+    }
+
+    func testMorningNudgeWrapsAcrossMidnight() {
+        // windowEnd 00:30 (30) => wake 23:30 => nudge 23:45 (1425), no negative/overflow.
+        XCTAssertEqual(LocalNotificationScheduler.morningNudgeMinutes(windowEnd: 30), 23 * 60 + 45)
+        let m = LocalNotificationScheduler.morningNudgeMinutes(windowEnd: 30)
+        XCTAssertTrue((0..<1440).contains(m))
+    }
 }

--- a/Atria/AtriaTests/AtriaRecoveryFreezeTests.swift
+++ b/Atria/AtriaTests/AtriaRecoveryFreezeTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+@testable import Atria
+
+/// Recovery-freeze staleness (2026-07-08 Scope 1): the frozen daily recovery is
+/// preserved all day, but must RE-MINT when the scored night's inputs change
+/// (sleep confirm / EXTEND / adjust) — otherwise the persisted recovery + trend
+/// point outlive the night they describe. Locks the pure change-detector so a
+/// night edit re-freezes while intra-day strain accrual never does.
+final class AtriaRecoveryFreezeTests: XCTestCase {
+    private func at(_ h: Double) -> Date { Date(timeIntervalSince1970: 1_800_000_000 + h * 3600) }
+
+    private func metric(sleepEnd: Date? = nil,
+                        sleepDuration: TimeInterval? = 7 * 3600,
+                        sleepSpan: TimeInterval? = 7.5 * 3600,
+                        hrv: Int? = 45,
+                        restingHR: Int? = 52,
+                        respiratoryRate: Double? = 14,
+                        recoveryPercent: Int? = 70,
+                        strain: Double? = 5) -> SavedDailyMetric {
+        SavedDailyMetric(day: at(0), recoveryPercent: recoveryPercent, recoveryConfidence: "local",
+                         hrv: hrv, restingHR: restingHR, respiratoryRate: respiratoryRate,
+                         sleepDuration: sleepDuration, sleepSpan: sleepSpan,
+                         sleepStart: nil, sleepEnd: sleepEnd, sleepSource: "auto_sleep",
+                         sleepStageSegments: [], sleepConsistencyPercent: nil, strain: strain)
+    }
+
+    func testUnchangedNightIsNotAChange() {
+        let a = metric(sleepEnd: at(6))
+        XCTAssertFalse(SessionStore.dailyRecoveryInputsChanged(frozen: a, fresh: a))
+    }
+
+    func testExtendedNightEndTriggersRemint() {
+        // Wake-then-sleep-again grew the night 0h→6h into 0h→8h.
+        let frozen = metric(sleepEnd: at(6), sleepDuration: 6 * 3600)
+        let extended = metric(sleepEnd: at(8), sleepDuration: 8 * 3600)
+        XCTAssertTrue(SessionStore.dailyRecoveryInputsChanged(frozen: frozen, fresh: extended))
+    }
+
+    func testChangedReadinessInputsTriggerRemint() {
+        let frozen = metric(sleepEnd: at(6))
+        XCTAssertTrue(SessionStore.dailyRecoveryInputsChanged(frozen: frozen, fresh: metric(sleepEnd: at(6), hrv: 52)))
+        XCTAssertTrue(SessionStore.dailyRecoveryInputsChanged(frozen: frozen, fresh: metric(sleepEnd: at(6), restingHR: 48)))
+        XCTAssertTrue(SessionStore.dailyRecoveryInputsChanged(frozen: frozen, fresh: metric(sleepEnd: at(6), respiratoryRate: 16)))
+        XCTAssertTrue(SessionStore.dailyRecoveryInputsChanged(frozen: frozen, fresh: metric(sleepEnd: at(6), sleepSpan: 8 * 3600)))
+    }
+
+    func testStrainAccrualOrRecoveryOutputAloneIsNotANightChange() {
+        // Strain accrues all day and recovery is the OUTPUT, not an input — a
+        // difference in either must NOT re-mint, or the daily freeze is defeated.
+        let frozen = metric(sleepEnd: at(6), recoveryPercent: 70, strain: 3)
+        let laterInDay = metric(sleepEnd: at(6), recoveryPercent: 55, strain: 12)
+        XCTAssertFalse(SessionStore.dailyRecoveryInputsChanged(frozen: frozen, fresh: laterInDay))
+    }
+}

--- a/Atria/AtriaTests/AtriaSleepExtendTests.swift
+++ b/Atria/AtriaTests/AtriaSleepExtendTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import Atria
+
+/// Sleep wake-expansion (user 2026-07-08): a wake-then-sleep-again should EXTEND
+/// the confirmed night. Locks the pure extend-only decision so it can only GROW
+/// an AUTO night — never shrink, split, trim the head, absorb a separate nap, or
+/// clobber a user-authored/edited night. (Hardened after an adversarial review
+/// found a manual-night-clobber blocker + a head-trim.)
+final class AtriaSleepExtendTests: XCTestCase {
+    private func at(_ h: Double) -> Date { Date(timeIntervalSince1970: 1_800_000_000 + h * 3600) }
+
+    private func candidate(kind: String = "unambiguous_hr", start: Date, end: Date) -> AggregateSleepCandidate {
+        AggregateSleepCandidate(
+            kind: kind, day: start, sessions: 1, start: start, end: end,
+            duration: end.timeIntervalSince(start), span: end.timeIntervalSince(start),
+            maxGap: 0, samples: 100, avgHR: 55, peakHR: 70, hrStandardDeviation: 3,
+            medianHR: 55, hrP90: 62, elevatedSampleFraction: 0.01, restingHR: 52,
+            confidence: .high, reason: "test", motionHintCount: 0, motionHintKinds: "",
+            motionEvidenceSource: "none", motionEvidenceValidated: false, motionShortCount: 0,
+            motionShortMean: nil, motionShortMin: nil, motionShortMax: nil, motionShortOverOneCount: 0,
+            historicalMotionStatus: "none", historicalMotionReason: "none", historicalMotionRows: 0,
+            historicalMotionValidatedRows: 0, historicalMotionCoverageSeconds: 0,
+            historicalMotionMeanVectorDelta: nil, historicalMotionP95VectorDelta: nil,
+            historicalMotionMagnitudeStdDev: nil, historicalMotionArchiveFirstUnix: 0,
+            historicalMotionArchiveLastUnix: 0, historicalMotionNearestSeparationSeconds: 0,
+            historicalMotionValidated: false)
+    }
+
+    private func sleep(source: String = "auto_sleep", start: Date, end: Date) -> UserConfirmedSleep {
+        UserConfirmedSleep(
+            id: "\(source)-\(Int(start.timeIntervalSince1970))", createdAt: start,
+            start: start, end: end, source: source, confidence: "high", sessions: 1,
+            samples: 100, avgHR: 55, peakHR: 70, restingHR: 52, hrv: 40, hrvWindowCount: 10,
+            duration: end.timeIntervalSince(start), span: end.timeIntervalSince(start),
+            reason: "test", motionSource: "none", motionValidated: false, stageSegments: nil)
+    }
+
+    func testExtendsAutoNightWhenReSleepGrowsIt() {
+        // Confirmed auto night 0h→7h; user re-sleeps, candidate now spans 0h→9h.
+        XCTAssertTrue(SessionStore.sleepExtendReplacement(
+            existing: [sleep(start: at(0), end: at(7))], candidate: candidate(start: at(0), end: at(9))))
+    }
+
+    func testDoesNotExtendWhenNoLaterEnd() {
+        let existing = [sleep(start: at(0), end: at(9))]
+        XCTAssertFalse(SessionStore.sleepExtendReplacement(existing: existing, candidate: candidate(start: at(0), end: at(9))))
+        XCTAssertFalse(SessionStore.sleepExtendReplacement(existing: existing, candidate: candidate(start: at(0), end: at(7))))
+    }
+
+    func testDoesNotExtendForNapCandidate() {
+        XCTAssertFalse(SessionStore.sleepExtendReplacement(
+            existing: [sleep(start: at(0), end: at(7))], candidate: candidate(kind: "nap_candidate", start: at(0), end: at(9))))
+    }
+
+    func testDoesNotAbsorbSeparateLaterWindow() {
+        XCTAssertFalse(SessionStore.sleepExtendReplacement(
+            existing: [sleep(start: at(0), end: at(7))], candidate: candidate(start: at(14), end: at(16))))
+    }
+
+    func testDoesNotExtendWhenOnlyANapOverlaps() {
+        XCTAssertFalse(SessionStore.sleepExtendReplacement(
+            existing: [sleep(source: "manual_nap", start: at(4), end: at(5.5))], candidate: candidate(start: at(4), end: at(9))))
+    }
+
+    // BLOCKER fix: a manual / user-adjusted night must NEVER be clobbered by extend.
+    func testDoesNotClobberUserAuthoredNight() {
+        for source in ["manual_sleep", "user_adjusted_sleep"] {
+            XCTAssertFalse(SessionStore.sleepExtendReplacement(
+                existing: [sleep(source: source, start: at(0), end: at(7))],
+                candidate: candidate(start: at(0), end: at(9))),
+                "\(source) must be left alone by the auto extend")
+        }
+        XCTAssertTrue(SessionStore.isUserAuthoredSleepSource("manual_sleep"))
+        XCTAssertTrue(SessionStore.isUserAuthoredSleepSource("user_adjusted_nap"))
+        XCTAssertFalse(SessionStore.isUserAuthoredSleepSource("auto_confirmed_sleep"))
+    }
+
+    // Head-trim fix: a later-starting cluster (e.g. split off by a >2h strap-dead
+    // gap) must NOT extend — that would trim the head / fabricate across the gap.
+    func testDoesNotTrimHeadWithLaterStartingCandidate() {
+        XCTAssertFalse(SessionStore.sleepExtendReplacement(
+            existing: [sleep(start: at(0), end: at(7))], candidate: candidate(start: at(2), end: at(9))))
+    }
+}

--- a/Atria/AtriaTests/AtriaSleepPlannerTests.swift
+++ b/Atria/AtriaTests/AtriaSleepPlannerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import Atria
+
+/// Sleep Planner math (2026-07-07): goal fractions, efficiency learning
+/// gate, and the worked-back bedtime including midnight wrap.
+final class AtriaSleepPlannerTests: XCTestCase {
+    func testPeakPlanWorksBackFromWake() {
+        // Need 8h, wake by 6:30 (390), learned efficiency 0.9 from 5 nights:
+        // in bed 8/0.9 = 8h53m before 6:30 → 21:37.
+        let plan = AtriaSleepPlanner.plan(needHours: 8, goal: .peak, wakeByMinutes: 390,
+                                          nightEfficiencies: [0.9, 0.9, 0.9, 0.9, 0.9])
+        XCTAssertEqual(plan.targetSleepHours, 8)
+        XCTAssertFalse(plan.efficiencyIsDefault)
+        XCTAssertEqual(plan.inBedByMinutes, (390 - 533 + 1440) % 1440)
+    }
+
+    func testBedtimeWrapsPastMidnight() {
+        let plan = AtriaSleepPlanner.plan(needHours: 8, goal: .peak, wakeByMinutes: 390,
+                                          nightEfficiencies: [0.9, 0.9, 0.9, 0.9, 0.9])
+        XCTAssertEqual(plan.inBedByMinutes, (390 - 533 + 1440) % 1440)
+        XCTAssertEqual(plan.inBedByMinutes, 1297)  // 21:37
+    }
+
+    func testGetByAimsForSeventyPercent() {
+        let plan = AtriaSleepPlanner.plan(needHours: 10, goal: .getBy, wakeByMinutes: 420,
+                                          nightEfficiencies: [])
+        XCTAssertEqual(plan.targetSleepHours, 7.0, accuracy: 0.001)
+        XCTAssertTrue(plan.efficiencyIsDefault)
+        XCTAssertEqual(plan.assumedEfficiency, 0.90, accuracy: 0.001)
+    }
+
+    func testEfficiencyNeedsFiveRealNights() {
+        let learning = AtriaSleepPlanner.assumedEfficiency(nightEfficiencies: [0.8, 0.8, 0.8, 0.8])
+        XCTAssertTrue(learning.isDefault)
+        let learned = AtriaSleepPlanner.assumedEfficiency(nightEfficiencies: [0.8, 0.82, 0.84, 0.86, 0.88])
+        XCTAssertFalse(learned.isDefault)
+        XCTAssertEqual(learned.value, 0.84, accuracy: 0.001)
+        // Junk efficiencies (holes, >1) never count toward the gate.
+        let junk = AtriaSleepPlanner.assumedEfficiency(nightEfficiencies: [0.2, 1.4, 0.9, 0.9, 0.9])
+        XCTAssertTrue(junk.isDefault)
+    }
+}

--- a/Atria/AtriaTests/AtriaStrainConsistencyTests.swift
+++ b/Atria/AtriaTests/AtriaStrainConsistencyTests.swift
@@ -35,4 +35,18 @@ final class AtriaStrainConsistencyTests: XCTestCase {
                                                  rest: 60, maxHR: 190)
         XCTAssertEqual(strains.count, 2)
     }
+    // Recovery honesty (2026-07-08 audit): unknown in-bed span must NOT read as
+    // 100% efficiency — return nil so recovery skips the sleep signal.
+    func testSleepEfficiencyNilWhenSpanUnknown() {
+        XCTAssertNil(SessionStore.sleepEfficiency(duration: 7 * 3600, span: nil))
+        XCTAssertNil(SessionStore.sleepEfficiency(duration: nil, span: 8 * 3600))
+    }
+
+    func testSleepEfficiencyComputesWhenSpanKnown() {
+        let e = SessionStore.sleepEfficiency(duration: 7 * 3600, span: 8 * 3600)
+        XCTAssertEqual(e ?? 0, 0.875, accuracy: 0.001)
+        // span shorter than duration clamps to <= 1 (never > 100%).
+        XCTAssertEqual(SessionStore.sleepEfficiency(duration: 8 * 3600, span: 7 * 3600) ?? 0, 1.0, accuracy: 0.001)
+    }
 }
+

--- a/Atria/AtriaTests/AtriaStrainConsistencyTests.swift
+++ b/Atria/AtriaTests/AtriaStrainConsistencyTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Atria
+
+/// Strain-trend consistency (2026-07-08 audit): a day's strain is
+/// score(SUM of session TRIMPs), NOT the average of per-session scores. Since
+/// score() saturates, averaging per-session scores under-reports ~2x — the
+/// trend chart used to disagree with every other strain surface.
+final class AtriaStrainConsistencyTests: XCTestCase {
+    private func workout(start: Date, bpm: Int, minutes: Int) -> SavedSession {
+        let pts = stride(from: 0, through: minutes * 60, by: 10).map { SavedSession.Point(t: Double($0), bpm: bpm) }
+        return SavedSession(id: UUID(), start: start, end: start.addingTimeInterval(Double(minutes * 60)),
+                            label: "Workout", points: pts, respiratoryRate: nil, rrPoints: [],
+                            sleepWakeResearchState: nil)
+    }
+
+    func testPerDayStrainSumsWithinDayAndBeatsPerSessionAverage() {
+        let day = Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 1_800_000_000)).addingTimeInterval(10 * 3600)
+        let s1 = workout(start: day, bpm: 150, minutes: 25)
+        let s2 = workout(start: day.addingTimeInterval(3600), bpm: 150, minutes: 25)
+        let strains = SessionStore.perDayStrains([s1, s2], rest: 60, maxHR: 190)
+        XCTAssertEqual(strains.count, 1, "two same-day sessions collapse to one day strain")
+        let t1 = s1.trimp(rest: 60, max: 190), t2 = s2.trimp(rest: 60, max: 190)
+        XCTAssertGreaterThan(t1, 0)
+        XCTAssertEqual(strains[0], Metrics.strain(fromTRIMP: t1 + t2), accuracy: 0.01)
+        let perSessionAverage = (Metrics.strain(fromTRIMP: t1) + Metrics.strain(fromTRIMP: t2)) / 2
+        XCTAssertGreaterThan(strains[0], perSessionAverage + 0.5,
+                             "day-summed strain must exceed per-session average (the ~2x under-report)")
+    }
+
+    func testPerDayStrainSeparatesDifferentDays() {
+        let day1 = Calendar.current.startOfDay(for: Date(timeIntervalSince1970: 1_800_000_000)).addingTimeInterval(10 * 3600)
+        let day2 = day1.addingTimeInterval(48 * 3600)
+        let strains = SessionStore.perDayStrains([workout(start: day1, bpm: 150, minutes: 25),
+                                                  workout(start: day2, bpm: 150, minutes: 25)],
+                                                 rest: 60, maxHR: 190)
+        XCTAssertEqual(strains.count, 2)
+    }
+}

--- a/Atria/AtriaTests/AtriaWeeklyPlanLabelTests.swift
+++ b/Atria/AtriaTests/AtriaWeeklyPlanLabelTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Atria
+
+/// The "This week" label shows a plain date range (2026-07-08 UX audit)
+/// instead of the ISO week number "W28".
+final class AtriaWeeklyPlanLabelTests: XCTestCase {
+    func testWeekLabelIsAPlainDateRangeNotAnISOWeekNumber() {
+        let plan = WeeklyPlan(rollups: [], now: Date(timeIntervalSince1970: 1_783_600_000))
+        let text = plan.dateRangeText
+        XCTAssertFalse(text.isEmpty, "should produce a label")
+        XCTAssertFalse(text.contains("W"), "no month abbreviation contains W, so this catches an ISO 'W28': \(text)")
+        XCTAssertTrue(text.contains("–"), "should be a start–end range: \(text)")
+        // Leads with a month abbreviation (plain language), not a digit.
+        XCTAssertTrue(text.first?.isLetter == true, "should start with a month name: \(text)")
+    }
+}

--- a/Atria/AtriaTests/AtriaWorkoutOnsetTests.swift
+++ b/Atria/AtriaTests/AtriaWorkoutOnsetTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import Atria
+
+/// Workout onset detection (2026-07-07, early-boundary fix). At rest 66 /
+/// max 190 the elevated threshold is 128 bpm, so getting-ready HR (~105) is
+/// sub-threshold and must be trimmed; the real workout onset is the first
+/// sustained >=128 run. These lock the honesty guards (never fabricate a
+/// boundary; fail closed to nil).
+final class AtriaWorkoutOnsetTests: XCTestCase {
+    private func samples(_ segments: [(seconds: Int, bpm: Int)], start: Date) -> [(t: Date, bpm: Int)] {
+        var out: [(t: Date, bpm: Int)] = []
+        var offset = 0
+        for segment in segments {
+            for _ in 0..<segment.seconds {
+                out.append((start.addingTimeInterval(TimeInterval(offset)), segment.bpm))
+                offset += 1
+            }
+        }
+        return out
+    }
+
+    func testTrimsSubThresholdLeadInToFirstSustainedRun() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        // 26 min getting-ready (~105 bpm) + 45 min workout (~140 bpm).
+        let s = samples([(1_560, 105), (2_700, 140)], start: start)
+        let onset = AtriaWorkoutOnset.firstSustainedElevatedOnset(samples: s, rest: 66, maxHR: 190)
+        XCTAssertNotNil(onset)
+        XCTAssertEqual(onset!.timeIntervalSince(start), 1_560, accuracy: 2)
+    }
+
+    func testNoElevatedRunReturnsNil() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        XCTAssertNil(AtriaWorkoutOnset.firstSustainedElevatedOnset(
+            samples: samples([(3_600, 100)], start: start), rest: 66, maxHR: 190))
+    }
+
+    func testBriefSpikeBelowMinimumOnsetReturnsNil() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        // 60s elevated (< 90s minimum) between rest — not a sustained onset.
+        XCTAssertNil(AtriaWorkoutOnset.firstSustainedElevatedOnset(
+            samples: samples([(600, 100), (60, 140), (600, 100)], start: start), rest: 66, maxHR: 190))
+    }
+
+    func testHardGapResetsTheBout() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        var s = samples([(50, 140)], start: start)
+        s += samples([(50, 140)], start: start.addingTimeInterval(50 + 30)) // 30s gap > 15s limit
+        XCTAssertNil(AtriaWorkoutOnset.firstSustainedElevatedOnset(samples: s, rest: 66, maxHR: 190))
+    }
+
+    func testMicroGapReconnectBlipDoesNotSeedOnset() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        var s = samples([(600, 100)], start: start)
+        s.append((start.addingTimeInterval(604), 140)) // 4s gap + 40 bpm jump = unverified blip
+        s += samples([(600, 100)], start: start.addingTimeInterval(605))
+        XCTAssertNil(AtriaWorkoutOnset.firstSustainedElevatedOnset(samples: s, rest: 66, maxHR: 190))
+    }
+}

--- a/Atria/AtriaTests/AtriaWorkoutOnsetTests.swift
+++ b/Atria/AtriaTests/AtriaWorkoutOnsetTests.swift
@@ -55,4 +55,36 @@ final class AtriaWorkoutOnsetTests: XCTestCase {
         s += samples([(600, 100)], start: start.addingTimeInterval(605))
         XCTAssertNil(AtriaWorkoutOnset.firstSustainedElevatedOnset(samples: s, rest: 66, maxHR: 190))
     }
+
+    // windowStats: the trimmed-window HR stats must reflect ONLY the given
+    // (trimmed) samples — the honesty bug the self-review caught was avg being
+    // computed over the untrimmed window.
+    func testWindowStatsAveragesOnlyTheGivenSamples() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let s = samples([(39 * 60, 150)], start: start) // 39 min of real effort at 150
+        let stats = AtriaWorkoutOnset.windowStats(samples: s, windowSeconds: 39 * 60)
+        XCTAssertNotNil(stats)
+        XCTAssertEqual(stats!.avgHR, 150)
+        XCTAssertEqual(stats!.peakHR, 150)
+        XCTAssertEqual(stats!.streamCoveragePercent, 100)
+    }
+
+    func testWindowStatsCoverageExcludesGaps() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        var s = samples([(75, 140)], start: start)
+        s += samples([(75, 140)], start: start.addingTimeInterval(225)) // 150s gap in a 300s window
+        let stats = AtriaWorkoutOnset.windowStats(samples: s, windowSeconds: 300)
+        XCTAssertNotNil(stats)
+        XCTAssertLessThan(stats!.streamCoveragePercent, 60)
+        XCTAssertGreaterThan(stats!.streamCoveragePercent, 40)
+    }
+
+    func testWindowStatsPercentiles() {
+        let start = Date(timeIntervalSince1970: 1_800_000_000)
+        let s: [(t: Date, bpm: Int)] = (0..<100).map { (start.addingTimeInterval(TimeInterval($0)), 100 + $0) }
+        let stats = AtriaWorkoutOnset.windowStats(samples: s, windowSeconds: 100)
+        XCTAssertNotNil(stats)
+        XCTAssertEqual(stats!.peakHR, 199)
+        XCTAssertGreaterThanOrEqual(stats!.p95HR, 190)
+    }
 }

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -3250,7 +3250,9 @@ class HandoffStaticChecks(unittest.TestCase):
             "private let summary: SessionDetailSummary",
             "init(session: SavedSession)",
             "self.displayedPoints = Self.downsampledPoints(session.points)",
-            "self.summary = SessionDetailSummary(session: session, maxHR: AthleteProfile.load().maxHR)",
+            # 2026-07-08: SessionDetailSummary now takes the baseline `rest`
+            # (matching the rollups) so a workout's strain reconciles everywhere.
+            "self.summary = SessionDetailSummary(session: session,",
             "private static func downsampledPoints",
             "Chart(Array(displayedPoints.enumerated()), id: \\.offset)",
             "private struct SessionDetailSummary",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -3182,7 +3182,10 @@ class HandoffStaticChecks(unittest.TestCase):
             "cleanedActivityType",
             "cleanedExercises.isEmpty ? nil : cleanedExercises",
             "label: cleanedActivityType ?? \"Live workout\"",
-            "let enriched = confirmedWorkoutMetrics(start: bestStart,",
+            # 2026-07-07: enriched metrics now computed over the onset-trimmed
+            # displayStart (getting-ready lead-in removed); id/readiness stay
+            # on the untrimmed bestStart.
+            "let enriched = confirmedWorkoutMetrics(start: displayStart,",
             "strain: enriched.strain",
             "activeEnergyKilocalories: enriched.activeEnergyKilocalories",
             "activeEnergyConfidence: enriched.activeEnergyConfidence",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -817,7 +817,10 @@ class HandoffStaticChecks(unittest.TestCase):
             'Button(action: onShowStrap) {',
             'Button(action: onShowAssistant) {',
             'AtriaToolbarIcon(symbol: "applewatch.radiowaves.left.and.right")',
-            '"Coming Soon!"',
+            # 2026-07-08 user-directed: the Assistant is implemented
+            # (AtriaAssistantScreen — deterministic Q&A + opt-in coach card);
+            # the Coming Soon placeholder is gone.
+            'AtriaAssistantScreen(store: store,',
             ".tabBarMinimizeBehavior(.onScrollDown)",
             ".tabViewBottomAccessory",
             ".padding(.bottom, scrollBottomClearance)",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -1411,7 +1411,10 @@ class HandoffStaticChecks(unittest.TestCase):
             "case .personalBaseline:\n            base = \"Personal baseline\"",
             "if hero.recoveryEstimate.detail.localizedCaseInsensitiveContains(\"HRV baseline\")",
             "base = \"Building baseline\"",
-            "detail: hrvDetailText",
+            # 2026-07-08: HRV/RHR cards show the real baseline value + a "Calibrating ·
+            # night N of 14" detail during calibration (user "start showing something
+            # when we can"), with the zone judgment suppressed; else hrvDetailText/hrvZone.
+            "detail: hrvCalibratingValue != nil ? calibratingProgressDetail(samples: hrvBaselineSamples) : hrvDetailText",
             "private var hrvDetailText: String",
             "if detail.contains(\"validated\") { return \"Checked\" }",
             "if detail.contains(\"personal baseline\") || detail.contains(\"% kept\") { return \"Personal baseline\" }",
@@ -10796,10 +10799,10 @@ class HandoffStaticChecks(unittest.TestCase):
             "zone: recoveryZone",
             "zone: strainZone",
             "zone: loadReadinessZone",
-            "zone: hrvZone",
+            "zone: hrvCalibratingValue != nil ? nil : hrvZone",  # 2026-07-08 partial-data calibration
             "zone: sleepGlanceZone",
             "zone: sleepEfficiencyZone",
-            "zone: restingHeartRateZone",
+            "zone: restingCalibratingValue != nil ? nil : restingHeartRateZone",  # 2026-07-08 partial-data calibration
             "zone: stepsZone",
             "zone: activeCaloriesZone",
             "zone: vo2TrendZone",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -6218,7 +6218,8 @@ class HandoffStaticChecks(unittest.TestCase):
             ".background(.cyan.opacity(0.10), in: Capsule())",
             ".font(.headline.weight(.bold).monospacedDigit())",
             "private struct AtriaJournalImpactBar: View, Equatable",
-            'Label("Impact", systemImage: "waveform.path.ecg")',
+            # 2026-07-08: the inner 'Impact' header was removed (it duplicated
+            # the outer 'Impacts' card header — card-in-card de-dup).
             "GeometryReader { proxy in",
             "let center = width / 2",
             "summary.impactProgress",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -8027,7 +8027,10 @@ class HandoffStaticChecks(unittest.TestCase):
             "static func estimate(samples: [(t: Date, ms: Double)],",
             "lookback: TimeInterval = 90",
             "static func estimate(resampledRR: [Double], sampleRate: Double = 4.0) -> Double?",
-            "for breathsPerMinute in stride(from: 6.0, through: 30.0, by: 0.5)",
+            # 2026-07-08: floor raised 6.0 -> 9.0 bpm (0.15 Hz HF-band floor)
+            # so HRV LF / Mayer-wave drift can no longer be reported as
+            # breathing (device showed a fabricated 6.5-8.2 bpm).
+            "for breathsPerMinute in stride(from: 9.0, through: 30.0, by: 0.5)",
             "bestPower / max(bandPower, bestPower) >= 0.18",
         ]:
             assert_contains(self, text, needle)

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -3944,7 +3944,9 @@ class HandoffStaticChecks(unittest.TestCase):
             "Stage breakdown needs checked sleep-stage evidence; duration, RHR, HRV, and respiratory estimates stay visible while Atria learns.",
             "AtriaSleepStageBuildingSummary(night: latest)",
             "Awake, Light, REM, SWS, and Deep are not ready yet.",
-            "private struct AtriaSleepStageHypnogram: View, Equatable",
+            # 2026-07-08: de-privatized so the broader-lane sizing (user request)
+            # is render-testable.
+            "struct AtriaSleepStageHypnogram: View, Equatable",
             "Canvas { context, size in",
             "drawGuides(in: &context, size: size)",
             "drawSegments(in: &context, size: size)",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -8092,7 +8092,8 @@ class HandoffStaticChecks(unittest.TestCase):
         assert_contains(self, home, "sleepDurationHours: latestSleep?.durationHours")
         assert_contains(self, notifications, "sleepEfficiency: latestSleep?.sleepEfficiency")
         assert_contains(self, notifications, "sleepDurationHours: latestSleep?.durationHours")
-        assert_contains(self, sessions, "private nonisolated static func sleepEfficiency(duration: TimeInterval?, span: TimeInterval?) -> Double?")
+        # 2026-07-08: de-privatized so the unknown-span honesty rule is testable.
+        assert_contains(self, sessions, "nonisolated static func sleepEfficiency(duration: TimeInterval?, span: TimeInterval?) -> Double?")
         assert_contains(self, sessions, "sleepEfficiency: Self.sleepEfficiency(duration: sleepRollup?.sleepDuration,")
         assert_contains(self, sessions, "sleepDurationHours: sleepRollup?.sleepDuration.map { $0 / 3_600 }")
 

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -10712,7 +10712,10 @@ class HandoffStaticChecks(unittest.TestCase):
             assert_contains(self, vitals, needle)
         for needle in [
             "private var accessibilityText: String",
-            "var parts = [calibratingDay.map { \"\\(title) calibrating day \\(min(max($0, 1), 4)) of 4\" } ?? \"\\(title) \\(displayValue)\", detail]",
+            # 2026-07-08: calibration is honest per-metric — baselines (HRV/RHR) pass
+            # calibratingTotal:14 + calibratingUnit:"Night" for "Night X of 14"; recovery/
+            # sleep keep the default 4/"Day". Accessibility mirrors the visible unit+total.
+            "var parts = [calibratingDay.map { \"\\(title) calibrating \\(calibratingUnit.lowercased()) \\(min(max($0, 0), calibratingTotal)) of \\(calibratingTotal)\" } ?? \"\\(title) \\(displayValue)\", detail]",
             "parts.append(zone.level.label)",
             "parts.append(zone.targetSummary)",
             "parts.append(\"Tap info for guidance.\")",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -1098,11 +1098,13 @@ class HandoffStaticChecks(unittest.TestCase):
             "static func yDomain(for points: [AtriaHomeModel.HeartRateChartPoint]) -> ClosedRange<Int>",
             "func nearestPoint(to selectedTime: Date?) -> AtriaHomeModel.HeartRateChartPoint?",
             "@State private var series: AtriaHeartRateChartSeries",
-            "_series = State(initialValue: AtriaHeartRateChartSeries.make(points: points, zoom: 1))",
+            # 2026-07-07: HR-timeline explorer switched from point-count zoom
+            # to time-window zoom (12h default, 1min-24h), so series is built
+            # from a windowed slice.
+            "AtriaHeartRateChartSeries.make(",
             "AtriaHeartRateAxisChart(points: series.visiblePoints,",
             "yDomain: series.yDomain,",
-            "series = AtriaHeartRateChartSeries.make(points: points, zoom: newValue)",
-            "series = AtriaHeartRateChartSeries.make(points: newValue, zoom: zoom)",
+            "AtriaVitalsHeartRateTimeline.windowed(points, window: currentWindow, displayBudget: 400)",
             "struct AtriaHeartRateAxisChart: View, Equatable",
             "let yDomain: ClosedRange<Int>",
             "lhs.points == rhs.points && lhs.yDomain == rhs.yDomain",
@@ -1119,7 +1121,9 @@ class HandoffStaticChecks(unittest.TestCase):
             ".background(Color(.systemBackground).opacity(0.18), in: RoundedRectangle(cornerRadius: 12, style: .continuous))",
             ".mask(RoundedRectangle(cornerRadius: 12, style: .continuous))",
             ".clipShape(RoundedRectangle(cornerRadius: AtriaDesignTokens.Radius.inset, style: .continuous))",
-            "Slider(value: $zoom, in: 1...6, step: 1)",
+            # 2026-07-07: time-window zoom slider (1 min .. 24 hr) replaces
+            # the old 1...6 point-count zoom.
+            "Slider(value: $windowIndex,",
             "Label(\"Done\", systemImage: \"xmark\")",
             ".atriaCardAction(prominent: false, tint: .secondary)",
             ".fullScreenCover(isPresented: $showHeartRateExplorer)",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -6181,10 +6181,12 @@ class HandoffStaticChecks(unittest.TestCase):
             "impactLane(title: \"Watch\"",
             "impactLane(title: \"Support\"",
             "glanceChip(title: \"Logged\"",
-            "glanceChip(title: \"Links\"",
+            # 2026-07-08: "Links" (raw correlation count) renamed to plain
+            # "Patterns", with "—" instead of "0" in the empty state.
+            "glanceChip(title: \"Patterns\"",
             "glanceChip(title: \"Focus\"",
             "Journal impact glance. \\(taggedDays) logged days.",
-            "behavior links",
+            "behavior patterns",
             "Text(count == 1 ? \"1 link\" : \"\\(count) links\")",
             "private func impactLane(title: String,",
             "private func glanceChip(title: String,",

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -6898,7 +6898,11 @@ class HandoffStaticChecks(unittest.TestCase):
             "struct ResearchManeuverProbeCorrelationSummary: Equatable",
             "@Published private(set) var researchManeuverProbeCorrelationSummary",
             "private func recomputeCollectionResearchSummaries()",
-            "researchManeuverProbeCorrelationSummary = ResearchManeuverProbeCorrelationSummary(markers: cachedResearchManeuverMarkers",
+            # 2026-07-08: recompute moved off-main + coalesced (compute-cadence pass);
+            # markers still captured from the local cachedResearchManeuverMarkers,
+            # local-research-only, built off the sessions snapshot.
+            "let markers = cachedResearchManeuverMarkers",
+            "ResearchManeuverProbeCorrelationSummary(markers: markers, sessions: sessionsSnapshot)",
             "func markResearchManeuver(_ kind: ResearchManeuverMarker.Kind",
             "ATRIADBG research_maneuver_marker status=marked",
             "local_only=1 research_only=1 metric_promotions=0 healthkit_write=0 raw_storage=0",
@@ -8368,7 +8372,10 @@ class HandoffStaticChecks(unittest.TestCase):
             "var respiratoryRateText: String",
             "@Published private(set) var imuAuditSummary",
             "private func recomputeCollectionResearchSummaries()",
-            "imuAuditSummary = IMUAuditSummary(sessions: sessions)",
+            # 2026-07-08: research summaries now recompute OFF-main + coalesced
+            # (compute-cadence pass) — still built from the real sessions snapshot,
+            # nothing fabricated; published back on main.
+            "let imu = IMUAuditSummary(sessions: sessionsSnapshot)",
         ]:
             assert_contains(self, sessions, needle)
 


### PR DESCRIPTION
Merges the ui-loop-6 forward-usability + fix loop into main. The most recent session added 12 verified, device-verified fixes across the user's priority bugs + features; earlier commits on this branch carried the UI/design-handoff polish that preceded them.

## Priority bugs fixed
- **HR timeline** loads a full 24h span (was capped to ~1.7h); off-main downsample + debounced re-parse (`e1bf3e1e`)
- **Morning journal notification** — dedicated wake reminder decoupled from the sleep-gated summary, 14-day re-engage window (`9fd473a4`, `ba2e2c91`)
- **Sleep wake-expansion** — a wake-then-sleep-again grows the confirmed night; extend-only, protects manual edits, hardened by two adversarial-review passes (`e5a26068`)
- **Hangs** — three main-thread stalls removed: workout-detail trace cache, research summaries off-main, HR merge memoize (`49167c17`, `29321e15`)

## Features / honesty
- **Calibration honesty** — "Night X of 14" (real threshold) instead of a false "Day 4 of 4" ring (`89d12f4e`); **real HRV/RHR numbers shown during calibration** with an honest "night N/14" note (`df8e557a`)
- **Journal questions** — Energy, Focus, Wind-down scales that feed the existing correlation engine (`a85f98b5`, `d60a8681`)
- **WHOOP-style compute cadence** — fitness age computed weekly not per-refresh (`7d34e0f2`); recovery daily-metric re-mints when the scored night changes instead of going stale (`c9625e04`)

All 12 session commits pass the static-check gate + unit suite and were verified on a real iPhone (launch + no crash; daily-metric merge, sleep confirm, HR flow confirmed on-device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TsQpAAM7chXcoSvjAEkMP