### PR TITLE
UI/UX: empty-state honesty + recovery consistency + D/W/M period

### DIFF
--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -3125,7 +3125,11 @@ struct AtriaOverviewReadinessSection: View, Equatable {
     private var trendCard: some View {
         AtriaGlanceMetricCard(title: "Resting trend",
                               value: trendValues.count > 1 ? "\(trendValues.last ?? 0)" : "--",
-                              detail: trendValues.count > 1 ? "14 sessions" : "Learning",
+                              // Empty-state honesty (2026-07-08): a trend line needs two
+                              // nights to plot, so say exactly how far off it is ("0 of 2
+                              // nights") instead of a bare "Learning" — matches the "N of M"
+                              // progress the RHR/HRV cards already show.
+                              detail: trendValues.count > 1 ? "14 sessions" : "\(trendValues.count) of 2 nights",
                               systemImage: AtriaTodayMetric.trend.systemImage,
                               tint: .red,
                               sparklineValues: trendValues.count > 1 ? trendValues : [0, 0])

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6816,7 +6816,7 @@ struct AtriaMetricDetailSheet: View {
             // (2026-07-07, design handoff full-scroll mock).
             AtriaMetricDetailTemplate(heroValue: recoveryHeroValue,
                                       heroState: recoveryHeroState,
-                                      tint: recoveryEstimate.percent.map(Metrics.recoveryColor) ?? Metrics.electricGreen) {
+                                      tint: recoveryHeroRawPercent.map { Metrics.recoveryColor(Int($0.rounded())) } ?? Metrics.electricGreen) {
                 contributorCard
                 behaviorsMoveYouCard
             } contributors: {
@@ -7200,7 +7200,7 @@ struct AtriaMetricDetailSheet: View {
     private func chartSlot<Content: View>(@ViewBuilder content: () -> Content) -> some View {
         VStack(alignment: .leading, spacing: 16) {
             Picker("Range", selection: $range) {
-                ForEach(AtriaTrendRange.allCases) { option in
+                ForEach(AtriaTrendRange.primarySegments) { option in
                     Text(option.menuLabel).tag(option)
                 }
             }
@@ -7231,14 +7231,32 @@ struct AtriaMetricDetailSheet: View {
         .atriaInsetCard(tint: metric.tint)
     }
 
+    /// The recovery number behind the hero, per selected period, read from the
+    /// SAME frozen daily-rollup series the chart below plots — never the live
+    /// `recoveryEstimate` recompute. Day = that settled daily score (today's
+    /// saved recovery, else the newest saved day carried forward, exactly like
+    /// the overview tile / health row / widget), so the headline can no longer
+    /// drift onto the live value or contradict them for the same day. Week/Month
+    /// = the window average, so the number finally tracks the Day/Week/Month
+    /// selector (2026-07-08: fixes recovery showing a fixed live % that both
+    /// ignored the period and disagreed with the day value shown everywhere else).
+    private var recoveryHeroRawPercent: Double? {
+        if range == .day {
+            return preparedHistory.recoverySummary[range]?.latestRaw
+                ?? preparedHistory.recoveryRaw[.all]?.last?.value
+        }
+        return preparedHistory.recoverySummary[range]?.averageRaw
+    }
+
     private var recoveryHeroValue: String {
-        recoveryEstimate.percent.map { "\($0)%" } ?? "Day 1"
+        guard let percent = recoveryHeroRawPercent else { return "Learning" }
+        return AtriaDetailPeriodSummary.valueText(percent, unit: "%")
     }
 
     private var recoveryHeroState: String {
         // Canonical not-ready word is "Learning" (never "Building") — must match
         // the recovery ring center + legend chip for the same Day-1 state.
-        guard let percent = recoveryEstimate.percent else { return "Learning" }
+        guard let percent = recoveryHeroRawPercent.map({ Int($0.rounded()) }) else { return "Learning" }
         switch percent {
         case 67...: return "Good"
         case 34..<67: return "Typical"

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -2947,7 +2947,7 @@ struct AtriaOverviewReadinessSection: View, Equatable {
         case .sleepEfficiency:
             AtriaGlanceMetricCard(title: "Sleep eff",
                                   value: sleepHistory.latest?.sleepEfficiencyText ?? "Learning",
-                                  detail: sleepHistory.latest?.sleepEfficiency == nil ? "Learning" : "Duration-based",
+                                  detail: sleepHistory.latest?.sleepEfficiency == nil ? "Needs time in bed" : "Duration-based",
                                   systemImage: metric.systemImage,
                                   tint: sleepEfficiencyZone?.tint ?? (sleepHistory.latest?.sleepEfficiency == nil ? .orange : .cyan),
                                   zone: sleepEfficiencyZone,

--- a/Atria/Atria/AtriaOverviewSections.swift
+++ b/Atria/Atria/AtriaOverviewSections.swift
@@ -6841,7 +6841,7 @@ struct AtriaMetricDetailSheet: View {
                 aboutDisclosure
             }
         case .hrv:
-            AtriaMetricDetailTemplate(heroValue: latestMetricText(points: preparedHistory.hrv[range] ?? [], unit: "ms"),
+            AtriaMetricDetailTemplate(heroValue: periodHeroText(summary: preparedHistory.hrvSummary[range], points: preparedHistory.hrv[range] ?? [], unit: "ms"),
                                       heroState: hrvBand == nil ? learningNightsState(baseline.hrvSampleCount) : "Typical",
                                       tint: metric.tint) {
                 AtriaMetricContributorRows(rows: [
@@ -6872,7 +6872,7 @@ struct AtriaMetricDetailSheet: View {
                 aboutDisclosure
             }
         case .restingHeartRate:
-            AtriaMetricDetailTemplate(heroValue: latestMetricText(points: preparedHistory.restingHeartRate[range] ?? [], unit: "bpm"),
+            AtriaMetricDetailTemplate(heroValue: periodHeroText(summary: preparedHistory.restingHeartRateSummary[range], points: preparedHistory.restingHeartRate[range] ?? [], unit: "bpm"),
                                       heroState: restingBand == nil ? learningNightsState(baseline.restingSampleCount) : "Typical",
                                       tint: metric.tint) {
                 AtriaMetricContributorRows(rows: [
@@ -6903,7 +6903,7 @@ struct AtriaMetricDetailSheet: View {
                 aboutDisclosure
             }
         case .respiratoryRate:
-            AtriaMetricDetailTemplate(heroValue: latestMetricText(points: preparedHistory.respiratoryRate[range] ?? [], unit: "/min"),
+            AtriaMetricDetailTemplate(heroValue: periodHeroText(summary: preparedHistory.respiratoryRateSummary[range], points: preparedHistory.respiratoryRate[range] ?? [], unit: "/min"),
                                       heroState: respiratoryBand == nil ? "Learning" : "Typical",
                                       tint: metric.tint) {
                 AtriaMetricContributorRows(rows: [
@@ -6930,7 +6930,7 @@ struct AtriaMetricDetailSheet: View {
                 aboutDisclosure
             }
         case .sleep:
-            AtriaMetricDetailTemplate(heroValue: latestMetricText(points: preparedHistory.sleep[range] ?? [], unit: "h"),
+            AtriaMetricDetailTemplate(heroValue: periodHeroText(summary: preparedHistory.sleepSummary[range], points: preparedHistory.sleep[range] ?? [], unit: "h"),
                                       heroState: sleepHeroState,
                                       tint: Metrics.electricSleep) {
                 if let latest = sleepHistory.latest {
@@ -6965,7 +6965,7 @@ struct AtriaMetricDetailSheet: View {
                 aboutDisclosure
             }
         case .strain:
-            AtriaMetricDetailTemplate(heroValue: latestMetricText(points: preparedHistory.strain[range] ?? [], unit: ""),
+            AtriaMetricDetailTemplate(heroValue: periodHeroText(summary: preparedHistory.strainSummary[range], points: preparedHistory.strain[range] ?? [], unit: ""),
                                       heroState: strainHeroState,
                                       tint: Metrics.electricStrain) {
                 strainWorkoutSection
@@ -6999,7 +6999,7 @@ struct AtriaMetricDetailSheet: View {
                 aboutDisclosure
             }
         case .sleepPerformance:
-            AtriaMetricDetailTemplate(heroValue: latestMetricText(points: preparedHistory.sleepPerformance[range] ?? [], unit: "%"),
+            AtriaMetricDetailTemplate(heroValue: periodHeroText(summary: preparedHistory.sleepPerformanceSummary[range], points: preparedHistory.sleepPerformance[range] ?? [], unit: "%"),
                                       heroState: sleepPerformanceHeroState,
                                       tint: Metrics.electricSleep) {
                 EmptyView()
@@ -7678,6 +7678,22 @@ struct AtriaMetricDetailSheet: View {
     private func latestMetricText(points: [AtriaDetailChartPoint], unit: String) -> String {
         guard let latest = points.last else { return "--" }
         return latestText(value: latest.value, unit: unit)
+    }
+
+    /// The detail-hero headline for the selected period. Day = the latest reading
+    /// (unchanged); Week/Month/… = the window AVERAGE, read from the SAME per-range
+    /// summary the chart's Avg strip uses, so the headline tracks the selector and
+    /// agrees with the chart. Falls back to the latest reading when no summary yet.
+    /// (2026-07-08: the headline was the latest point for every range, identical
+    /// across Day/Week/Month, so the number looked frozen to the selector — the same
+    /// class of bug the user reported for recovery.)
+    private func periodHeroText(summary: AtriaDetailPeriodSummary?,
+                                points: [AtriaDetailChartPoint],
+                                unit: String) -> String {
+        if range != .day, let summary {
+            return summary.averageText
+        }
+        return latestMetricText(points: points, unit: unit)
     }
 
     private var contributorCard: some View {

--- a/Atria/Atria/AtriaTodayScreen.swift
+++ b/Atria/Atria/AtriaTodayScreen.swift
@@ -1377,7 +1377,10 @@ struct AtriaTodayScreen: View {
             return AtriaTodayGlanceItem(title: metric.label,
                                         metricKey: metric.rawValue,
                                         value: latestSleep?.sleepEfficiencyText ?? "--",
-                                        detail: legendDetail("Sleep"),
+                                        // Empty-state honesty (2026-07-08): efficiency = time asleep /
+                                        // time in bed, so until a night has a known in-bed span it reads
+                                        // "Needs time in bed" rather than a bare category label.
+                                        detail: legendDetail(latestSleep?.sleepEfficiency == nil ? "Needs time in bed" : "Sleep"),
                                         systemImage: metric.systemImage,
                                         tint: Metrics.electricSleep,
                                         layoutSize: layoutSize(for: metric))
@@ -1396,11 +1399,13 @@ struct AtriaTodayScreen: View {
             return AtriaTodayGlanceItem(title: metric.label,
                                         metricKey: metric.rawValue,
                                         value: displayHero.restingHeartRateText,
-                                        // RHR is measured nightly and is shown from night 1, so unlike
-                                        // HRV it has no multi-night "calibrating" value state — its text
-                                        // is always numeric. Keep the plain unit; a nights-progress
-                                        // caption here would mislabel a ready reading as pending.
-                                        detail: legendDetail("bpm"),
+                                        // RHR shares HRV's 14-night personal baseline: when no resting
+                                        // reading exists yet, restingHeartRateText is "Learning", so mirror
+                                        // the HRV tile and show honest "N of 14 nights" progress while
+                                        // pending; once a real reading arrives, show the plain "bpm" unit.
+                                        detail: legendDetail(isPendingHeroValue(displayHero.restingHeartRateText)
+                                                             ? baselineNightsProgress(store.baseline.freshRestingSampleCount())
+                                                             : "bpm"),
                                         systemImage: metric.systemImage,
                                         tint: .pink,
                                         layoutSize: layoutSize(for: metric))
@@ -1408,7 +1413,7 @@ struct AtriaTodayScreen: View {
             return AtriaTodayGlanceItem(title: metric.label,
                                         metricKey: metric.rawValue,
                                         value: latestRollup?.respiratoryRate.map { String(format: "%.1f", $0) } ?? "--",
-                                        detail: legendDetail("/min"),
+                                        detail: legendDetail(latestRollup?.respiratoryRate == nil ? "After a sleep" : "/min"),
                                         systemImage: metric.systemImage,
                                         tint: .teal,
                                         layoutSize: layoutSize(for: metric))

--- a/Atria/Atria/AtriaTrendChart.swift
+++ b/Atria/Atria/AtriaTrendChart.swift
@@ -45,7 +45,7 @@ struct AtriaTrendChartCard: View {
 
             VStack(spacing: 8) {
                 Picker("Range", selection: $range) {
-                    ForEach(AtriaTrendRange.allCases) { item in
+                    ForEach(AtriaTrendRange.primarySegments) { item in
                         Text(item.segmentedLabel)
                             .tag(item)
                             .accessibilityLabel(item.menuLabel)
@@ -2347,6 +2347,15 @@ enum AtriaTrendRange: String, CaseIterable, Identifiable {
     case all
 
     var id: String { rawValue }
+
+    /// Interactive selectors expose only Day/Week/Month — the daily/weekly/monthly
+    /// model the app is built around. The deeper cases (quarter/sixMonths/year/all)
+    /// stay in the enum and `allCases`: both per-range data-prep loops
+    /// (AtriaTrendChart.swift + AtriaOverviewSections.swift) and the internal `.all`
+    /// read still key off the full set — they are just not offered in the range bar
+    /// (2026-07-08: declutter the range bar to D/W/M per user request; the range
+    /// selector stays a segmented control, never a Menu, per the readability guard).
+    static let primarySegments: [AtriaTrendRange] = [.day, .week, .month]
 
     var days: Int {
         switch self {

--- a/Atria/AtriaTests/AtriaRecoveryFreezeTests.swift
+++ b/Atria/AtriaTests/AtriaRecoveryFreezeTests.swift
@@ -51,4 +51,21 @@ final class AtriaRecoveryFreezeTests: XCTestCase {
         let laterInDay = metric(sleepEnd: at(6), recoveryPercent: 55, strain: 12)
         XCTAssertFalse(SessionStore.dailyRecoveryInputsChanged(frozen: frozen, fresh: laterInDay))
     }
+
+    // MARK: - Period selector reduced to D/W/M (2026-07-08)
+
+    /// The interactive range bars now offer only Day/Week/Month.
+    func testPrimarySegmentsAreDayWeekMonth() {
+        XCTAssertEqual(AtriaTrendRange.primarySegments, [.day, .week, .month])
+    }
+
+    /// Dropping the deeper ranges from the UI must NOT drop them from the enum:
+    /// the per-range chart/summary data-prep loops and the internal `.all` read
+    /// (yesterday-strain) still key off the full CaseIterable set.
+    func testDeeperRangesStayInAllCasesForDataPrep() {
+        for deeper in [AtriaTrendRange.quarter, .sixMonths, .year, .all] {
+            XCTAssertTrue(AtriaTrendRange.allCases.contains(deeper),
+                          "\(deeper) must remain in allCases for range math + data prep")
+        }
+    }
 }

--- a/test_handoff_static_checks.py
+++ b/test_handoff_static_checks.py
@@ -8940,7 +8940,9 @@ class HandoffStaticChecks(unittest.TestCase):
             "confirmedWorkouts: store.confirmedWorkouts",
             "confirmedWorkouts: debugMetricDetailWorkouts ?? confirmedWorkouts",
             "let confirmedWorkouts: [UserConfirmedWorkout]",
-            "AtriaMetricDetailTemplate(heroValue: latestMetricText(points: preparedHistory.strain[range] ?? [], unit: \"\"),",
+            # 2026-07-08: detail heroes now route through periodHeroText (Day = latest,
+            # Week/Month = window average) so the headline tracks the range selector.
+            "AtriaMetricDetailTemplate(heroValue: periodHeroText(summary: preparedHistory.strainSummary[range], points: preparedHistory.strain[range] ?? [], unit: \"\"),",
             "strainWorkoutSection",
             "AtriaMetricContributorRows(rows: strainContributorRows, tint: Metrics.electricStrain)",
             "private var strainActivityContributorRows: [AtriaMetricContributorRow]",


### PR DESCRIPTION
Follows up ui-loop-6 (PR #14) with the UI/UX pass the user asked for.

## Empty-state honesty (the "Learning" states now tell you when data arrives)
- **Resting HR** → "N of 14 nights" while pending (mirrors the HRV tile; 14-night personal baseline), then "bpm"
- **Resp rate** → "After a sleep" (per-overnight-sleep signal — deliberately *not* a 14-night countdown), then "/min"
- **Sleep eff** → "Needs time in bed" (efficiency = time asleep / time in bed), then "Sleep"
- All strings adversarially honesty-verified against the real calibration gate (no fabricated value/timeline). Fixed in the *live* `AtriaTodayScreen` grid.

## Recovery consistency (39% vs 67% bug)
The recovery detail headline read the **live** `Metrics.recoveryV2` recompute and never indexed the period `range` — so it (a) ignored the Day/Week/Month selector and (b) disagreed with the frozen morning value the tile/health row/widget show. Now it reads the **same frozen daily-rollup series** the chart plots: Day = that settled day's recovery (carried like the tile, so it matches the 67%), Week/Month = the window average. The same period-invariance is fixed for HRV/RHR/sleep/strain/sleep-perf headlines via a shared `periodHeroText` helper (Day = latest, unchanged; Week/Month = average).

## Period selector → D/W/M
The range bar offered 7 options (D/W/M/3M/6M/1Y/All). The two live segmented bars now show only **Day / Week / Month**; deeper cases stay in the enum so all per-range data-prep + the internal `.all` read are untouched. Kept a segmented control (no Menu) per the readability guard.

## Verified
Static (pins migrated) + full unit suite pass (+ new range tests). Screenshot-verified on the sim: empty-state cards render the new strings (Resp rate confirmed), and the recovery-detail sheet shows the D/W/M-only bar with a consistent headline.

## Known follow-up
The overview *tiles* render live values while detail sheets read the frozen rollup — a today-in-progress tile can still differ from its detail sheet for HRV/RHR/sleep/strain (recovery is fully reconciled). Needs a product call on which source is canonical per tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TsQpAAM7chXcoSvjAEkMP